### PR TITLE
Added go-json-rest, httptreemux & Goji results.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Benchmark System:
  * Mac OS X 10.9.3
  
 ```
+#GithubAPI Routes: 203
+#GPlusAPI Routes: 13
+#ParseAPI Routes: 26
+#Static Routes: 157
+
+
 benchmarkgocraftweb_param          1000000     1323     ns/op       672     B/op        9     allocs/op
 benchmarkgoji_param                5000000     682      ns/op       343     B/op        2     allocs/op
 benchmarkgojsonrest_param          500000      4981     ns/op       1793    B/op        30    allocs/op


### PR DESCRIPTION
I've just updated the README to include results from routers that already had benchmarks in the code, but that didn't have results listed.

Have also updated system specifications to reflect machine results were generated on.
