### PR TITLE
adding bear benchmarks and updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Of course the tested routers can be used for any kind of HTTP request → handle
 
 #### Tested routers & frameworks:
 
+ * [Ace](https://github.com/plimble/ace)
+ * [Bear](https://github.com/ursiform/bear)
  * [Beego](http://beego.me/)
  * [go-json-rest](https://github.com/ant0ine/go-json-rest)
  * [Denco](https://github.com/naoina/denco)
@@ -44,10 +46,10 @@ So keep in mind, that I am not completely unbiased :relieved:
 ## Results
 
 Benchmark System:
- * Intel Core i5-2500K (4x 3,30GHz + Turbo Boost), CPU-governor: performance
- * 2x 4 GiB DDR3-1333 RAM, dual-channel
- * go version go1.3rc1 linux/amd64
- * Ubuntu 14.04 amd64 (Linux Kernel 3.13.0-29), fresh installation
+ * Intel Core i7 (4x 2.7GHz)
+ * 2x 8 GiB DDR3-1600 RAM
+ * go version go1.4 darwin/amd64
+ * OS X, 10.10.2
 
 
 ### Memory Consumption
@@ -58,24 +60,36 @@ The best 3 values for each test are bold. I'm pretty sure you can detect a patte
 
 | Router       | Static    | GitHub     | Google+   | Parse     |
 |:-------------|----------:|-----------:|----------:|----------:|
-| HttpServeMux |__18064 B__|         -  |        -  |        -  |
-| Beego        |  79472 B  |  497248 B  |  26480 B  |  38768 B  |
-| Denco        |  44752 B  |  107632 B  |  54896 B  |  36368 B  |
-| Gocraft Web  |  57976 B  |   95736 B  |   8024 B  |  13120 B  |
-| Goji         |  32400 B  | __58424 B__| __3392 B__| __6704 B__|
-| Go-Json-Rest | 152608 B  |  148352 B  |  11696 B  |  13712 B  |
-| Gorilla Mux  | 685152 B  | 1557216 B  |  80240 B  | 125480 B  |
-| HttpRouter   |__26232 B__| __44344 B__| __3144 B__| __5792 B__|
-| HttpTreeMux  |  75624 B  |   81408 B  |   7712 B  |   7616 B  |
-| Kocha        | 130336 B  |  811744 B  | 139968 B  | 191632 B  |
-| Martini      | 312592 B  |  579472 B  |  27520 B  |  50608 B  |
-| Pat          |__21272 B__| __18968 B__| __1448 B__| __2360 B__|
-| TigerTonic   |  85264 B  |   99392 B  |  10576 B  |  11008 B  |
-| Traffic      | 649568 B  | 1124704 B  |  57984 B  |  98168 B  |
+| HttpServeMux |  17728 B  |         _  |        _  |        _  |
+| Ace          |  37720 B  |   60520 B  |   4280 B  |   7968 B  |
+| Bear         |  36760 B  |   92008 B  |   7672 B  |  13344 B  |
+| Beego        | 103032 B  |  164984 B  |  11368 B  |  21040 B  |
+| Bone         |  40560 B  |   92960 B  |   6160 B  |  10672 B  |
+| Denco        | __9408 B__|   36440 B  |   3256 B  | __4184 B__|
+| Gin          |  41760 B  |   66896 B  |   4800 B  |   8712 B  |
+| GocraftWeb   |  51288 B  |   88840 B  |   7032 B  |  12128 B  |
+| Goji         |  29728 B  |   50568 B  | __3136 B__|   5664 B  |
+| GoJsonRest   | 142256 B  |  140640 B  |  17696 B  |  20368 B  |
+| GoRestful    | 886200 B  | 1369208 B  |  89176 B  | 142856 B  |
+| GorillaMux   | 668512 B  | 1493136 B  |  71056 B  | 122136 B  |
+| HttpRouter   |  25064 B  |   44184 B  |   3144 B  |   5792 B  |
+| HttpTreeMux  |  73288 B  |   74992 B  |   7120 B  |   7616 B  |
+| Kocha        | 114816 B  |  785120 B  | 128880 B  | 181712 B  |
+| Macaron      |  52168 B  |  102664 B  |   8264 B  |  13384 B  |
+| Martini      | 309040 B  |  476992 B  |  23904 B  |  45952 B  |
+| Pat          |__15704 B__| __15832 B__| __1448 B__| __1976 B__|
+| Revel        |  93600 B  |  141296 B  |  10768 B  |  15488 B  |
+| Rivet        |  42872 B  |  110080 B  |   7896 B  |  13496 B  |
+| Tango        | 256032 B  | __22864 B__|   3168 B  |   4432 B  |
+| TigerTonic   |  80736 B  |   96240 B  |   9408 B  |   9840 B  |
+| Traffic      | 624416 B  | 1053488 B  |  49488 B  |  93496 B  |
+| Vulcan       | 624416 B  |  426208 B  |  25496 B  |  44504 B  |
+| Zeus         |__14560 B__| __15840 B__| __1456 B__| __1984 B__|
 
-The first place goes to [Pat](https://github.com/bmizerany/pat), followed by [HttpRouter](https://github.com/julienschmidt/httprouter) and [Goji](https://github.com/zenazn/goji/). Now, before everyone starts reading the documentation of Pat, `[SPOILER]` this low memory consumption comes at the price of relatively bad routing performance. The routing structure of Pat is simple - probably too simple. `[/SPOILER]`.
 
-Moreover main memory is cheap and usually not a scarce resource. As long as the router doesn't require Megabytes of memory, it should be no deal breaker. But it gives us a first hint how efficient or wasteful a router works.
+
+
+Main memory is cheap and usually not a scarce resource. As long as the router doesn't require Megabytes of memory, it should be no deal breaker. But it gives us a first hint how efficient or wasteful a router works.
 
 
 ### Static Routes
@@ -86,26 +100,37 @@ The only intention of this benchmark is to allow a comparison with the default r
 
 In the `StaticAll` benchmark each of 157 URLs is called once per repetition (op, *operation*). If you are unfamiliar with the `go test -bench` tool, the first number is the number of repetitions the `go test` tool made, to get a test running long enough for measurements. The second column shows the time in nanoseconds that a single repetition takes. The third number is the amount of heap memory allocated in bytes, the last one the average number of allocations made per repetition.
 
-The logs below show, that http.ServeMux has only medium performance, compared to more feature-rich routers. The fastest router only needs 1.8% of the time http.ServeMux needs.
+The logs below show, that http.ServeMux has only medium performance, compared to more feature-rich routers. The fastest router only needs 1.5% of the time http.ServeMux needs.
 
 [HttpRouter](https://github.com/julienschmidt/httprouter) was the first router (I know of) that managed to serve all the static URLs without a single heap allocation. Since [the first run of this benchmark](https://github.com/julienschmidt/go-http-routing-benchmark/blob/0eb78904be13aee7a1e9f8943386f7c26b9d9d79/README.md) more routers followed this trend and were optimized in the same way.
 
 ```
-BenchmarkHttpServeMux_StaticAll         5000     706222 ns/op          96 B/op        6 allocs/op
+BenchmarkHttpServeMux_StaticAll  2000       845916 ns/op          96 B/op          8 allocs/op
 
-BenchmarkBeego_StaticAll                2000    1408954 ns/op      482433 B/op    14088 allocs/op
-BenchmarkDenco_StaticAll              200000      12679 ns/op           0 B/op        0 allocs/op
-BenchmarkGocraftWeb_StaticAll          10000     154142 ns/op       51468 B/op      947 allocs/op
-BenchmarkGoji_StaticAll                20000      80518 ns/op           0 B/op        0 allocs/op
-BenchmarkGoJsonRest_StaticAll           2000     978164 ns/op      180973 B/op     3945 allocs/op
-BenchmarkGorillaMux_StaticAll           1000    1763690 ns/op       71804 B/op      956 allocs/op
-BenchmarkHttpRouter_StaticAll         100000      15010 ns/op           0 B/op        0 allocs/op
-BenchmarkHttpTreeMux_StaticAll        100000      15123 ns/op           0 B/op        0 allocs/op
-BenchmarkKocha_StaticAll              100000      23093 ns/op           0 B/op        0 allocs/op
-BenchmarkMartini_StaticAll               500    3444278 ns/op      156015 B/op     2351 allocs/op
-BenchmarkPat_StaticAll                  1000    1640745 ns/op      549187 B/op    11186 allocs/op
-BenchmarkTigerTonic_StaticAll          50000      58264 ns/op        7714 B/op      157 allocs/op
-BenchmarkTraffic_StaticAll               500    7230129 ns/op     3763731 B/op    27453 allocs/op
+BenchmarkAce_StaticAll           50000       26512 ns/op           0 B/op          0 allocs/op
+BenchmarkBear_StaticAll          10000      129529 ns/op       26520 B/op        619 allocs/op
+BenchmarkBeego_StaticAll         10000      214671 ns/op       57744 B/op       1099 allocs/op
+BenchmarkBone_StaticAll          30000       42939 ns/op           0 B/op          0 allocs/op
+BenchmarkDenco_StaticAll         100000      12685 ns/op           0 B/op          0 allocs/op
+BenchmarkGin_StaticAll           50000       28448 ns/op           0 B/op          0 allocs/op
+BenchmarkGocraftWeb_StaticAll    10000      152033 ns/op       47696 B/op        942 allocs/op
+BenchmarkGoji_StaticAll          20000       63010 ns/op           0 B/op          0 allocs/op
+BenchmarkGoJsonRest_StaticAll    300       5017869 ns/op      610135 B/op      15066 allocs/op
+BenchmarkGoRestful_StaticAll     300       4752691 ns/op      294345 B/op       5007 allocs/op
+BenchmarkGorillaMux_StaticAll    1000      1745932 ns/op       72944 B/op       1264 allocs/op
+BenchmarkHttpRouter_StaticAll    100000      14535 ns/op           0 B/op          0 allocs/op
+BenchmarkHttpTreeMux_StaticAll   100000      14595 ns/op           0 B/op          0 allocs/op
+BenchmarkKocha_StaticAll         100000      22398 ns/op           0 B/op          0 allocs/op
+BenchmarkMacaron_StaticAll       5000       340507 ns/op      118032 B/op       1256 allocs/op
+BenchmarkMartini_StaticAll       500       3258465 ns/op      140352 B/op       2335 allocs/op
+BenchmarkPat_StaticAll           1000      1488026 ns/op      533904 B/op      11123 allocs/op
+BenchmarkRevel_StaticAll         2000       804102 ns/op      204528 B/op       3925 allocs/op
+BenchmarkRivet_StaticAll         20000       69601 ns/op       17584 B/op        314 allocs/op
+BenchmarkTango_StaticAll         1000      2360343 ns/op       54848 B/op       1544 allocs/op
+BenchmarkTigerTonic_StaticAll    30000       54839 ns/op        7504 B/op        157 allocs/op
+BenchmarkTraffic_StaticAll       1000      1902986 ns/op      732248 B/op      14444 allocs/op
+BenchmarkVulcan_StaticAll        1000      1926207 ns/op      732248 B/op      14444 allocs/op
+BenchmarkZeus_StaticAll          30000       53468 ns/op        4736 B/op         48 allocs/op
 ```
 
 ### Micro Benchmarks
@@ -114,67 +139,111 @@ The following benchmarks measure the cost of some very basic operations.
 
 In the first benchmark, only a single route, containing a parameter, is loaded into the routers. Then a request for a URL matching this pattern is made and the router has to call the respective registered handler function. End.
 ```
-BenchmarkBeego_Param                  500000       5495 ns/op        1165 B/op       14 allocs/op
-BenchmarkDenco_Param                 5000000        312 ns/op          50 B/op        2 allocs/op
-BenchmarkGocraftWeb_Param            1000000       1440 ns/op         684 B/op        9 allocs/op
-BenchmarkGoji_Param                  5000000        748 ns/op         340 B/op        2 allocs/op
-BenchmarkGoJsonRest_Param             500000       6980 ns/op        1787 B/op       29 allocs/op
-BenchmarkGorillaMux_Param            1000000       2665 ns/op         780 B/op        7 allocs/op
-BenchmarkHttpRouter_Param           20000000        139 ns/op          33 B/op        1 allocs/op
-BenchmarkHttpTreeMux_Param           5000000        558 ns/op         340 B/op        2 allocs/op
-BenchmarkKocha_Param                 5000000        377 ns/op          58 B/op        2 allocs/op
-BenchmarkMartini_Param                500000       6265 ns/op        1251 B/op       12 allocs/op
-BenchmarkPat_Param                   1000000       1620 ns/op         670 B/op       11 allocs/op
-BenchmarkTigerTonic_Param            1000000       2766 ns/op        1015 B/op       18 allocs/op
-BenchmarkTraffic_Param                500000       4440 ns/op        2013 B/op       22 allocs/op
+BenchmarkAce_Param          10000000    188 ns/op          32 B/op          1 allocs/op
+BenchmarkBear_Param         1000000    1174 ns/op         496 B/op          6 allocs/op
+BenchmarkBeego_Param        1000000    1854 ns/op         720 B/op         10 allocs/op
+BenchmarkBone_Param         2000000     831 ns/op         384 B/op          3 allocs/op
+BenchmarkDenco_Param        10000000    196 ns/op          32 B/op          1 allocs/op
+BenchmarkGin_Param          10000000    201 ns/op          32 B/op          1 allocs/op
+BenchmarkGocraftWeb_Param   1000000    1455 ns/op         656 B/op          9 allocs/op
+BenchmarkGoji_Param         2000000     736 ns/op         336 B/op          2 allocs/op
+BenchmarkGoJsonRest_Param   50000     31624 ns/op        4208 B/op         98 allocs/op
+BenchmarkGoRestful_Param    500000     2812 ns/op         568 B/op         16 allocs/op
+BenchmarkGorillaMux_Param   1000000    2859 ns/op         784 B/op          9 allocs/op
+BenchmarkHttpRouter_Param   10000000    131 ns/op          32 B/op          1 allocs/op
+BenchmarkHttpTreeMux_Param  3000000     586 ns/op         336 B/op          2 allocs/op
+BenchmarkKocha_Param        5000000     352 ns/op          56 B/op          3 allocs/op
+BenchmarkMacaron_Param      1000000    3072 ns/op        1144 B/op         13 allocs/op
+BenchmarkMartini_Param      300000     5988 ns/op        1152 B/op         12 allocs/op
+BenchmarkPat_Param          1000000    1704 ns/op         656 B/op         14 allocs/op
+BenchmarkRevel_Param        300000     5789 ns/op        1672 B/op         28 allocs/op
+BenchmarkRivet_Param        2000000     932 ns/op         464 B/op          5 allocs/op
+BenchmarkTango_Param        1000000    1825 ns/op         712 B/op         13 allocs/op
+BenchmarkTigerTonic_Param   1000000    2793 ns/op         992 B/op         19 allocs/op
+BenchmarkTraffic_Param      300000     4558 ns/op        1984 B/op         23 allocs/op
+BenchmarkVulcan_Param       2000000     758 ns/op          98 B/op          3 allocs/op
+BenchmarkZeus_Param         1000000    1027 ns/op         421 B/op          6 allocs/op
 ```
 
 Same as before, but now with multiple parameters, all in the same single route. The intention is to see how the routers scale with the number of parameters. The values of the parameters must be passed to the handler function somehow, which requires allocations. Let's see how clever the routers solve this task with a route containing 5 and 20 parameters:
 ```
-BenchmarkBeego_Param5                 100000      18473 ns/op        1291 B/op       14 allocs/op
-BenchmarkDenco_Param5                2000000        982 ns/op         405 B/op        5 allocs/op
-BenchmarkGocraftWeb_Param5           1000000       2218 ns/op         957 B/op       12 allocs/op
-BenchmarkGoji_Param5                 1000000       1093 ns/op         340 B/op        2 allocs/op
-BenchmarkGoJsonRest_Param5            200000      10462 ns/op        3264 B/op       40 allocs/op
-BenchmarkGorillaMux_Param5            500000       4680 ns/op         906 B/op        7 allocs/op
-BenchmarkHttpRouter_Param5           5000000        319 ns/op         162 B/op        1 allocs/op
-BenchmarkHttpTreeMux_Param5          2000000        898 ns/op         340 B/op        2 allocs/op
-BenchmarkKocha_Param5                1000000       1326 ns/op         448 B/op        7 allocs/op
-BenchmarkMartini_Param5               200000      13027 ns/op        1376 B/op       12 allocs/op
-BenchmarkPat_Param5                   500000       3416 ns/op        1435 B/op       18 allocs/op
-BenchmarkTigerTonic_Param5            200000       9247 ns/op        2568 B/op       41 allocs/op
-BenchmarkTraffic_Param5               500000       7206 ns/op        2312 B/op       26 allocs/op
+BenchmarkAce_Param5             5000000           404 ns/op         160 B/op          1 allocs/op
+BenchmarkBear_Param5            1000000          1837 ns/op         560 B/op          6 allocs/op
+BenchmarkBeego_Param5           1000000          2724 ns/op         992 B/op         13 allocs/op
+BenchmarkBone_Param5            1000000          1196 ns/op         432 B/op          3 allocs/op
+BenchmarkDenco_Param5           3000000           476 ns/op         160 B/op          1 allocs/op
+BenchmarkGin_Param5             3000000           414 ns/op         160 B/op          1 allocs/op
+BenchmarkGocraftWeb_Param5      1000000          2232 ns/op         928 B/op         12 allocs/op
+BenchmarkGoji_Param5            1000000          1072 ns/op         336 B/op          2 allocs/op
+BenchmarkGoJsonRest_Param5      50000           33555 ns/op        4688 B/op        101 allocs/op
+BenchmarkGoRestful_Param5       500000           3327 ns/op         568 B/op         16 allocs/op
+BenchmarkGorillaMux_Param5      300000           4755 ns/op         912 B/op          9 allocs/op
+BenchmarkHttpRouter_Param5      5000000           337 ns/op         160 B/op          1 allocs/op
+BenchmarkHttpTreeMux_Param5     2000000           878 ns/op         336 B/op          2 allocs/op
+BenchmarkKocha_Param5           1000000          1360 ns/op         440 B/op         10 allocs/op
+BenchmarkMacaron_Param5         500000           3876 ns/op        1416 B/op         16 allocs/op
+BenchmarkMartini_Param5         200000          12523 ns/op        1280 B/op         12 allocs/op
+BenchmarkPat_Param5             500000           4322 ns/op        1008 B/op         42 allocs/op
+BenchmarkRevel_Param5           200000           6823 ns/op        2024 B/op         35 allocs/op
+BenchmarkRivet_Param5           1000000          1545 ns/op         528 B/op          9 allocs/op
+BenchmarkTango_Param5           500000           3063 ns/op         856 B/op         29 allocs/op
+BenchmarkTigerTonic_Param5      200000           9510 ns/op        2519 B/op         53 allocs/op
+BenchmarkTraffic_Param5         200000           7277 ns/op        2280 B/op         31 allocs/op
+BenchmarkVulcan_Param5          1000000          1023 ns/op          98 B/op          3 allocs/op
+BenchmarkZeus_Param5            1000000          1795 ns/op         592 B/op          9 allocs/op
 
-BenchmarkBeego_Param20                 10000     106746 ns/op        3681 B/op       17 allocs/op
-BenchmarkDenco_Param20               1000000       2882 ns/op        1666 B/op        7 allocs/op
-BenchmarkGocraftWeb_Param20           500000       7156 ns/op        3857 B/op       16 allocs/op
-BenchmarkGoji_Param20                1000000       3197 ns/op        1260 B/op        2 allocs/op
-BenchmarkGoJsonRest_Param20           100000      25809 ns/op       10605 B/op       75 allocs/op
-BenchmarkGorillaMux_Param20           200000       9885 ns/op        3295 B/op        9 allocs/op
-BenchmarkHttpRouter_Param20          2000000        954 ns/op         646 B/op        1 allocs/op
-BenchmarkHttpTreeMux_Param20          500000       5016 ns/op        2216 B/op        4 allocs/op
-BenchmarkKocha_Param20                500000       4268 ns/op        1836 B/op       17 allocs/op
-BenchmarkMartini_Param20               50000      55039 ns/op        3765 B/op       14 allocs/op
-BenchmarkPat_Param20                  500000       3412 ns/op        1435 B/op       18 allocs/op
-BenchmarkTigerTonic_Param20            50000      36825 ns/op       10710 B/op      131 allocs/op
-BenchmarkTraffic_Param20              100000      22605 ns/op        8077 B/op       49 allocs/op
+BenchmarkAce_Param20            1000000          1138 ns/op         640 B/op          1 allocs/op
+BenchmarkBear_Param20           200000           6731 ns/op        2667 B/op          8 allocs/op
+BenchmarkBeego_Param20          200000           8081 ns/op        3867 B/op         17 allocs/op
+BenchmarkBone_Param20           300000           5565 ns/op        2540 B/op          5 allocs/op
+BenchmarkDenco_Param20          1000000          1503 ns/op         640 B/op          1 allocs/op
+BenchmarkGin_Param20            1000000          1149 ns/op         640 B/op          1 allocs/op
+BenchmarkGocraftWeb_Param20     200000           7407 ns/op        3803 B/op         16 allocs/op
+BenchmarkGoji_Param20           1000000          3160 ns/op        1247 B/op          2 allocs/op
+BenchmarkGoJsonRest_Param20     30000           42759 ns/op        8114 B/op        105 allocs/op
+BenchmarkGoRestful_Param20      500000           4000 ns/op         568 B/op         16 allocs/op
+BenchmarkGorillaMux_Param20     200000          10464 ns/op        3276 B/op         11 allocs/op
+BenchmarkHttpRouter_Param20     1000000          1069 ns/op         640 B/op          1 allocs/op
+BenchmarkHttpTreeMux_Param20    300000           5063 ns/op        2187 B/op          4 allocs/op
+BenchmarkKocha_Param20          300000           4323 ns/op        1808 B/op         27 allocs/op
+BenchmarkMacaron_Param20        200000           9183 ns/op        4292 B/op         20 allocs/op
+BenchmarkMartini_Param20        30000           54214 ns/op        3645 B/op         14 allocs/op
+BenchmarkPat_Param20            100000          19926 ns/op        4885 B/op        151 allocs/op
+BenchmarkRevel_Param20          100000          13015 ns/op        5551 B/op         54 allocs/op
+BenchmarkRivet_Param20          300000           6634 ns/op        2620 B/op         26 allocs/op
+BenchmarkTango_Param20          200000          11355 ns/op        3655 B/op         91 allocs/op
+BenchmarkTigerTonic_Param20     50000           38843 ns/op       10542 B/op        178 allocs/op
+BenchmarkTraffic_Param20        100000          23000 ns/op        7997 B/op         66 allocs/op
+BenchmarkVulcan_Param20         1000000          1774 ns/op          98 B/op          3 allocs/op
+BenchmarkZeus_Param20           200000           7830 ns/op        3356 B/op         26 allocs/op
 ```
 
 Now let's see how expensive it is to access a parameter. The handler function reads the value (by the name of the parameter, e.g. with a map lookup; depends on the router) and writes it to our [web scale storage](https://www.youtube.com/watch?v=b2F-DItXtZs) (`/dev/null`).
 ```
-BenchmarkBeego_ParamWrite             500000       6604 ns/op        1602 B/op       18 allocs/op
-BenchmarkDenco_ParamWrite            5000000        377 ns/op          50 B/op        2 allocs/op
-BenchmarkGocraftWeb_ParamWrite       1000000       1590 ns/op         693 B/op        9 allocs/op
-BenchmarkGoji_ParamWrite             2000000        818 ns/op         340 B/op        2 allocs/op
-BenchmarkGoJsonRest_ParamWrite        200000       8388 ns/op        2265 B/op       33 allocs/op
-BenchmarkGorillaMux_ParamWrite       1000000       2913 ns/op         780 B/op        7 allocs/op
-BenchmarkHttpRouter_ParamWrite      10000000        193 ns/op          33 B/op        1 allocs/op
-BenchmarkHttpTreeMux_ParamWrite      5000000        649 ns/op         340 B/op        2 allocs/op
-BenchmarkKocha_ParamWrite            5000000        435 ns/op          58 B/op        2 allocs/op
-BenchmarkMartini_ParamWrite           500000       7538 ns/op        1359 B/op       15 allocs/op
-BenchmarkPat_ParamWrite              1000000       2940 ns/op        1109 B/op       15 allocs/op
-BenchmarkTigerTonic_ParamWrite        500000       4639 ns/op        1471 B/op       23 allocs/op
-BenchmarkTraffic_ParamWrite           500000       5855 ns/op        2435 B/op       25 allocs/op
+BenchmarkAce_ParamWrite  5000000           297 ns/op          40 B/op          2 allocs/op
+BenchmarkBear_ParamWrite     1000000          1240 ns/op         504 B/op          7 allocs/op
+BenchmarkBeego_ParamWrite    1000000          1973 ns/op         728 B/op         11 allocs/op
+BenchmarkBone_ParamWrite     1000000          1030 ns/op         432 B/op          4 allocs/op
+BenchmarkDenco_ParamWrite    5000000           256 ns/op          32 B/op          1 allocs/op
+BenchmarkGin_ParamWrite  5000000           308 ns/op          40 B/op          2 allocs/op
+BenchmarkGocraftWeb_ParamWrite   1000000          1595 ns/op         664 B/op         10 allocs/op
+BenchmarkGoji_ParamWrite     2000000           794 ns/op         336 B/op          2 allocs/op
+BenchmarkGoJsonRest_ParamWrite     50000         33423 ns/op        4680 B/op        103 allocs/op
+BenchmarkGoRestful_ParamWrite     500000          2830 ns/op         568 B/op         16 allocs/op
+BenchmarkGorillaMux_ParamWrite    500000          3126 ns/op         792 B/op         10 allocs/op
+BenchmarkHttpRouter_ParamWrite  10000000           184 ns/op          32 B/op          1 allocs/op
+BenchmarkHttpTreeMux_ParamWrite  2000000           638 ns/op         336 B/op          2 allocs/op
+BenchmarkKocha_ParamWrite    3000000           413 ns/op          56 B/op          3 allocs/op
+BenchmarkMacaron_ParamWrite   500000          3551 ns/op        1208 B/op         15 allocs/op
+BenchmarkMartini_ParamWrite   200000          6896 ns/op        1256 B/op         16 allocs/op
+BenchmarkPat_ParamWrite  1000000          2875 ns/op        1088 B/op         19 allocs/op
+BenchmarkRevel_ParamWrite     200000          6750 ns/op        2128 B/op         33 allocs/op
+BenchmarkRivet_ParamWrite    1000000          1067 ns/op         472 B/op          6 allocs/op
+BenchmarkTango_ParamWrite    1000000          1859 ns/op         712 B/op         13 allocs/op
+BenchmarkTigerTonic_ParamWrite    300000          4566 ns/op        1440 B/op         25 allocs/op
+BenchmarkTraffic_ParamWrite   300000          5846 ns/op        2400 B/op         27 allocs/op
+BenchmarkVulcan_ParamWrite   2000000           758 ns/op          98 B/op          3 allocs/op
+BenchmarkZeus_ParamWrite     1000000          1253 ns/op         469 B/op          7 allocs/op
 ```
 
 ### [Parse.com](https://parse.com/docs/rest#summary)
@@ -186,61 +255,106 @@ The tasks are 1.) routing a static URL (no parameters), 2.) routing a URL contai
 Worth noting is, that the requested route might be a good case for some routing algorithms, while it is a bad case for another algorithm. The values might vary slightly depending on the selected route.
 
 ```
-BenchmarkBeego_ParseStatic            500000       3461 ns/op        1247 B/op       15 allocs/op
-BenchmarkDenco_ParseStatic          50000000         42.6 ns/op         0 B/op        0 allocs/op
-BenchmarkGocraftWeb_ParseStatic      2000000        889 ns/op         328 B/op        6 allocs/op
-BenchmarkGoji_ParseStatic            5000000        341 ns/op           0 B/op        0 allocs/op
-BenchmarkGoJsonRest_ParseStatic       500000       5860 ns/op        1136 B/op       25 allocs/op
-BenchmarkGorillaMux_ParseStatic      1000000       2760 ns/op         456 B/op        6 allocs/op
-BenchmarkHttpRouter_ParseStatic     50000000         36.7 ns/op         0 B/op        0 allocs/op
-BenchmarkHttpTreeMux_ParseStatic    50000000         62.6 ns/op         0 B/op        0 allocs/op
-BenchmarkKocha_ParseStatic          50000000         72.2 ns/op         0 B/op        0 allocs/op
-BenchmarkMartini_ParseStatic          500000       5528 ns/op         927 B/op       11 allocs/op
-BenchmarkPat_ParseStatic             2000000        809 ns/op         246 B/op        5 allocs/op
-BenchmarkTigerTonic_ParseStatic     10000000        264 ns/op          49 B/op        1 allocs/op
-BenchmarkTraffic_ParseStatic          500000       5008 ns/op        2377 B/op       24 allocs/op
+BenchmarkAce_ParseStatic    20000000            95.3 ns/op         0 B/op          0 allocs/op
+BenchmarkBear_ParseStatic    2000000           647 ns/op         160 B/op          4 allocs/op
+BenchmarkBeego_ParseStatic   1000000          1190 ns/op         368 B/op          7 allocs/op
+BenchmarkBone_ParseStatic    3000000           480 ns/op         144 B/op          3 allocs/op
+BenchmarkDenco_ParseStatic  30000000            44.6 ns/op         0 B/op          0 allocs/op
+BenchmarkGin_ParseStatic    20000000           110 ns/op           0 B/op          0 allocs/op
+BenchmarkGocraftWeb_ParseStatic  2000000           880 ns/op         304 B/op          6 allocs/op
+BenchmarkGoji_ParseStatic    5000000           284 ns/op           0 B/op          0 allocs/op
+BenchmarkGoJsonRest_ParseStatic    50000         31277 ns/op        3649 B/op         95 allocs/op
+BenchmarkGoRestful_ParseStatic    200000         10855 ns/op        2904 B/op         32 allocs/op
+BenchmarkGorillaMux_ParseStatic   500000          2826 ns/op         464 B/op          8 allocs/op
+BenchmarkHttpRouter_ParseStatic 50000000            36.3 ns/op         0 B/op          0 allocs/op
+BenchmarkHttpTreeMux_ParseStatic    20000000            60.2 ns/op         0 B/op          0 allocs/op
+BenchmarkKocha_ParseStatic  20000000            66.3 ns/op         0 B/op          0 allocs/op
+BenchmarkMacaron_ParseStatic     1000000          2099 ns/op         752 B/op          8 allocs/op
+BenchmarkMartini_ParseStatic      300000          4974 ns/op         832 B/op         11 allocs/op
+BenchmarkPat_ParseStatic     2000000           757 ns/op         240 B/op          5 allocs/op
+BenchmarkRevel_ParseStatic    500000          5028 ns/op        1288 B/op         25 allocs/op
+BenchmarkRivet_ParseStatic   5000000           371 ns/op         112 B/op          2 allocs/op
+BenchmarkTango_ParseStatic   1000000          1018 ns/op         320 B/op          8 allocs/op
+BenchmarkTigerTonic_ParseStatic  5000000           247 ns/op          48 B/op          1 allocs/op
+BenchmarkTraffic_ParseStatic      500000          3762 ns/op        1832 B/op         21 allocs/op
+BenchmarkVulcan_ParseStatic  2000000           853 ns/op          98 B/op          3 allocs/op
+BenchmarkZeus_ParseStatic    1000000          1002 ns/op         256 B/op          6 allocs/op
 
-BenchmarkBeego_ParseParam             500000       7983 ns/op        1775 B/op       28 allocs/op
-BenchmarkDenco_ParseParam            5000000        347 ns/op          50 B/op        2 allocs/op
-BenchmarkGocraftWeb_ParseParam       1000000       1535 ns/op         700 B/op        9 allocs/op
-BenchmarkGoji_ParseParam             2000000        983 ns/op         340 B/op        2 allocs/op
-BenchmarkGoJsonRest_ParseParam        500000       7208 ns/op        1789 B/op       29 allocs/op
-BenchmarkGorillaMux_ParseParam       1000000       3186 ns/op         780 B/op        7 allocs/op
-BenchmarkHttpRouter_ParseParam      10000000        178 ns/op          65 B/op        1 allocs/op
-BenchmarkHttpTreeMux_ParseParam      5000000        617 ns/op         340 B/op        2 allocs/op
-BenchmarkKocha_ParseParam            5000000        413 ns/op          58 B/op        2 allocs/op
-BenchmarkMartini_ParseParam           500000       7524 ns/op        1251 B/op       12 allocs/op
-BenchmarkPat_ParseParam              1000000       2707 ns/op        1160 B/op       18 allocs/op
-BenchmarkTigerTonic_ParseParam       1000000       3010 ns/op        1048 B/op       19 allocs/op
-BenchmarkTraffic_ParseParam           500000       5228 ns/op        2314 B/op       24 allocs/op
+BenchmarkAce_ParseParam 10000000           229 ns/op          64 B/op          1 allocs/op
+BenchmarkBear_ParseParam     1000000          1234 ns/op         512 B/op          6 allocs/op
+BenchmarkBeego_ParseParam    1000000          1915 ns/op         736 B/op         10 allocs/op
+BenchmarkBone_ParseParam     1000000          1087 ns/op         464 B/op          4 allocs/op
+BenchmarkDenco_ParseParam    5000000           249 ns/op          64 B/op          1 allocs/op
+BenchmarkGin_ParseParam  5000000           247 ns/op          64 B/op          1 allocs/op
+BenchmarkGocraftWeb_ParseParam   1000000          1506 ns/op         672 B/op          9 allocs/op
+BenchmarkGoji_ParseParam     2000000           933 ns/op         336 B/op          2 allocs/op
+BenchmarkGoJsonRest_ParseParam     50000         32233 ns/op        4208 B/op         98 allocs/op
+BenchmarkGoRestful_ParseParam     300000          6147 ns/op         568 B/op         16 allocs/op
+BenchmarkGorillaMux_ParseParam    500000          3244 ns/op         784 B/op          9 allocs/op
+BenchmarkHttpRouter_ParseParam  10000000           167 ns/op          64 B/op          1 allocs/op
+BenchmarkHttpTreeMux_ParseParam  3000000           608 ns/op         336 B/op          2 allocs/op
+BenchmarkKocha_ParseParam    5000000           379 ns/op          56 B/op          3 allocs/op
+BenchmarkMacaron_ParseParam  1000000          2779 ns/op        1120 B/op         11 allocs/op
+BenchmarkMartini_ParseParam   200000          7132 ns/op        1152 B/op         12 allocs/op
+BenchmarkPat_ParseParam  1000000          2659 ns/op        1136 B/op         20 allocs/op
+BenchmarkRevel_ParseParam     300000          5883 ns/op        1704 B/op         28 allocs/op
+BenchmarkRivet_ParseParam    2000000           964 ns/op         464 B/op          5 allocs/op
+BenchmarkTango_ParseParam    1000000          2760 ns/op        1176 B/op         19 allocs/op
+BenchmarkTigerTonic_ParseParam   1000000          2966 ns/op        1024 B/op         19 allocs/op
+BenchmarkTraffic_ParseParam   300000          5139 ns/op        2280 B/op         25 allocs/op
+BenchmarkVulcan_ParseParam   2000000           870 ns/op          98 B/op          3 allocs/op
+BenchmarkZeus_ParseParam     1000000          1626 ns/op         576 B/op          9 allocs/op
 
-BenchmarkBeego_Parse2Params           200000       9217 ns/op        1935 B/op       28 allocs/op
-BenchmarkDenco_Parse2Params          5000000        542 ns/op         115 B/op        3 allocs/op
-BenchmarkGocraftWeb_Parse2Params     1000000       1756 ns/op         750 B/op       10 allocs/op
-BenchmarkGoji_Parse2Params           2000000        954 ns/op         340 B/op        2 allocs/op
-BenchmarkGoJsonRest_Parse2Params      500000       8131 ns/op        2145 B/op       32 allocs/op
-BenchmarkGorillaMux_Parse2Params      500000       3623 ns/op         812 B/op        7 allocs/op
-BenchmarkHttpRouter_Parse2Params    10000000        202 ns/op          65 B/op        1 allocs/op
-BenchmarkHttpTreeMux_Parse2Params    5000000        708 ns/op         340 B/op        2 allocs/op
-BenchmarkKocha_Parse2Params          5000000        666 ns/op         132 B/op        4 allocs/op
-BenchmarkMartini_Parse2Params         200000       7723 ns/op        1283 B/op       12 allocs/op
-BenchmarkPat_Parse2Params            1000000       2687 ns/op         887 B/op       19 allocs/op
-BenchmarkTigerTonic_Parse2Params      500000       4720 ns/op        1473 B/op       28 allocs/op
-BenchmarkTraffic_Parse2Params         500000       5467 ns/op        2120 B/op       24 allocs/op
+BenchmarkAce_Parse2Params    5000000           252 ns/op          64 B/op          1 allocs/op
+BenchmarkBear_Parse2Params   1000000          1474 ns/op         544 B/op          6 allocs/op
+BenchmarkBeego_Parse2Params  1000000          2201 ns/op         784 B/op         11 allocs/op
+BenchmarkBone_Parse2Params   2000000           980 ns/op         416 B/op          3 allocs/op
+BenchmarkDenco_Parse2Params  5000000           297 ns/op          64 B/op          1 allocs/op
+BenchmarkGin_Parse2Params    5000000           276 ns/op          64 B/op          1 allocs/op
+BenchmarkGocraftWeb_Parse2Params     1000000          1740 ns/op         720 B/op         10 allocs/op
+BenchmarkGoji_Parse2Params   2000000           896 ns/op         336 B/op          2 allocs/op
+BenchmarkGoJsonRest_Parse2Params       50000         32619 ns/op        4272 B/op         99 allocs/op
+BenchmarkGoRestful_Parse2Params   200000          6579 ns/op         568 B/op         16 allocs/op
+BenchmarkGorillaMux_Parse2Params      500000          3696 ns/op         816 B/op          9 allocs/op
+BenchmarkHttpRouter_Parse2Params    10000000           193 ns/op          64 B/op          1 allocs/op
+BenchmarkHttpTreeMux_Parse2Params    2000000           674 ns/op         336 B/op          2 allocs/op
+BenchmarkKocha_Parse2Params  2000000           629 ns/op         128 B/op          5 allocs/op
+BenchmarkMacaron_Parse2Params    1000000          3009 ns/op        1168 B/op         12 allocs/op
+BenchmarkMartini_Parse2Params     200000          7441 ns/op        1184 B/op         12 allocs/op
+BenchmarkPat_Parse2Params    1000000          2618 ns/op         864 B/op         21 allocs/op
+BenchmarkRevel_Parse2Params   300000          6126 ns/op        1768 B/op         30 allocs/op
+BenchmarkRivet_Parse2Params  1000000          1106 ns/op         480 B/op          6 allocs/op
+BenchmarkTango_Parse2Params  1000000          2218 ns/op         776 B/op         17 allocs/op
+BenchmarkTigerTonic_Parse2Params      500000          4870 ns/op        1440 B/op         28 allocs/op
+BenchmarkTraffic_Parse2Params     300000          5415 ns/op        2088 B/op         25 allocs/op
+BenchmarkVulcan_Parse2Params     1000000          1051 ns/op          98 B/op          3 allocs/op
+BenchmarkZeus_Parse2Params   1000000          1481 ns/op         528 B/op          8 allocs/op
 
-BenchmarkBeego_ParseAll                10000     197920 ns/op       38877 B/op      616 allocs/op
-BenchmarkDenco_ParseAll               500000       7692 ns/op        1000 B/op       35 allocs/op
-BenchmarkGocraftWeb_ParseAll           50000      36226 ns/op       14639 B/op      208 allocs/op
-BenchmarkGoji_ParseAll                100000      19721 ns/op        5448 B/op       32 allocs/op
-BenchmarkGoJsonRest_ParseAll           10000     180128 ns/op       41202 B/op      727 allocs/op
-BenchmarkGorillaMux_ParseAll           10000     120929 ns/op       17138 B/op      173 allocs/op
-BenchmarkHttpRouter_ParseAll          500000       3592 ns/op         660 B/op       16 allocs/op
-BenchmarkHttpTreeMux_ParseAll         200000      11650 ns/op        5452 B/op       32 allocs/op
-BenchmarkKocha_ParseAll               200000       9371 ns/op        1163 B/op       44 allocs/op
-BenchmarkMartini_ParseAll              10000     200307 ns/op       29375 B/op      305 allocs/op
-BenchmarkPat_ParseAll                  50000      53113 ns/op       18017 B/op      363 allocs/op
-BenchmarkTigerTonic_ParseAll           50000      67208 ns/op       20547 B/op      419 allocs/op
-BenchmarkTraffic_ParseAll              10000     164938 ns/op       70161 B/op      743 allocs/op
+BenchmarkAce_ParseAll     300000          5341 ns/op         640 B/op         16 allocs/op
+BenchmarkBear_ParseAll     30000         49576 ns/op       15600 B/op        233 allocs/op
+BenchmarkBeego_ParseAll    30000         47858 ns/op       15600 B/op        233 allocs/op
+BenchmarkBone_ParseAll     50000         27212 ns/op        9296 B/op         99 allocs/op
+BenchmarkDenco_ParseAll   300000          5624 ns/op         928 B/op         16 allocs/op
+BenchmarkGin_ParseAll     300000          6433 ns/op         640 B/op         16 allocs/op
+BenchmarkGocraftWeb_ParseAll       50000         37088 ns/op       13936 B/op        207 allocs/op
+BenchmarkGoji_ParseAll    100000         18588 ns/op        5376 B/op         32 allocs/op
+BenchmarkGoji_ParseAll    100000             18588 ns/op            5376 B/op         32 allocs/op
+BenchmarkGoJsonRest_ParseAll        2000        871680 ns/op      105643 B/op       2527 allocs/op
+BenchmarkGoRestful_ParseAll     5000        343915 ns/op       97312 B/op        904 allocs/op
+BenchmarkGorillaMux_ParseAll       10000        124983 ns/op       17280 B/op        224 allocs/op
+BenchmarkHttpRouter_ParseAll      500000          3670 ns/op         640 B/op         16 allocs/op
+BenchmarkHttpTreeMux_ParseAll     200000         11484 ns/op        5376 B/op         32 allocs/op
+BenchmarkKocha_ParseAll   200000          9038 ns/op        1112 B/op         54 allocs/op
+BenchmarkMacaron_ParseAll      20000         73140 ns/op       25584 B/op        259 allocs/op
+BenchmarkMartini_ParseAll      10000        200863 ns/op       26848 B/op        302 allocs/op
+BenchmarkPat_ParseAll      30000         51573 ns/op       17568 B/op        382 allocs/op
+BenchmarkRevel_ParseAll    10000        152626 ns/op       40464 B/op        704 allocs/op
+BenchmarkRivet_ParseAll   100000         22562 ns/op        8592 B/op        103 allocs/op
+BenchmarkTango_ParseAll    30000         48243 ns/op       16560 B/op        330 allocs/op
+BenchmarkTigerTonic_ParseAll       20000         68300 ns/op       20032 B/op        417 allocs/op
+BenchmarkTraffic_ParseAll      10000        139429 ns/op       58496 B/op        687 allocs/op
+BenchmarkVulcan_ParseAll       50000         27106 ns/op        2548 B/op         78 allocs/op
+BenchmarkZeus_ParseAll     30000         56752 ns/op       18336 B/op        292 allocs/op
 ```
 
 
@@ -249,47 +363,80 @@ BenchmarkTraffic_ParseAll              10000     164938 ns/op       70161 B/op  
 The GitHub API is rather large, consisting of 203 routes. The tasks are basically the same as in the benchmarks before.
 
 ```
-BenchmarkBeego_GithubStatic           500000       3880 ns/op        1148 B/op       31 allocs/op
-BenchmarkDenco_GithubStatic         50000000         60.5 ns/op         0 B/op        0 allocs/op
-BenchmarkGocraftWeb_GithubStatic     2000000        933 ns/op         328 B/op        6 allocs/op
-BenchmarkGoji_GithubStatic           5000000        401 ns/op           0 B/op        0 allocs/op
-BenchmarkGoJsonRest_GithubStatic      500000       6006 ns/op        1150 B/op       25 allocs/op
-BenchmarkGorillaMux_GithubStatic      100000      18227 ns/op         456 B/op        6 allocs/op
-BenchmarkHttpRouter_GithubStatic    50000000         63.2 ns/op         0 B/op        0 allocs/op
-BenchmarkHttpTreeMux_GithubStatic   50000000         65.1 ns/op         0 B/op        0 allocs/op
-BenchmarkKocha_GithubStatic         20000000         99.5 ns/op         0 B/op        0 allocs/op
-BenchmarkMartini_GithubStatic         100000      18546 ns/op         927 B/op       11 allocs/op
-BenchmarkPat_GithubStatic             200000      11503 ns/op        3754 B/op       76 allocs/op
-BenchmarkTigerTonic_GithubStatic     5000000        308 ns/op          49 B/op        1 allocs/op
-BenchmarkTraffic_GithubStatic          50000      44923 ns/op       23105 B/op      168 allocs/op
+BenchmarkAce_GithubStatic   20000000           116 ns/op           0 B/op          0 allocs/op
+BenchmarkBear_GithubStatic   2000000           712 ns/op         160 B/op          4 allocs/op
+BenchmarkBeego_GithubStatic  1000000          1233 ns/op         368 B/op          7 allocs/op
+BenchmarkBone_GithubStatic    200000          9707 ns/op        2880 B/op         60 allocs/op
+BenchmarkDenco_GithubStatic 20000000            64.5 ns/op         0 B/op          0 allocs/op
+BenchmarkGin_GithubStatic   10000000           134 ns/op           0 B/op          0 allocs/op
+BenchmarkGocraftWeb_GithubStatic     2000000           893 ns/op         304 B/op          6 allocs/op
+BenchmarkGoji_GithubStatic   5000000           297 ns/op           0 B/op          0 allocs/op
+BenchmarkGoRestful_GithubStatic    50000         37217 ns/op        2968 B/op         34 allocs/op
+BenchmarkGoJsonRest_GithubStatic       50000         31305 ns/op        3888 B/op         96 allocs/op
+BenchmarkGorillaMux_GithubStatic      100000         19121 ns/op         464 B/op          8 allocs/op
+BenchmarkHttpRouter_GithubStatic    30000000            57.8 ns/op         0 B/op          0 allocs/op
+BenchmarkHttpTreeMux_GithubStatic   20000000            64.2 ns/op         0 B/op          0 allocs/op
+BenchmarkKocha_GithubStatic 20000000            93.1 ns/op         0 B/op          0 allocs/op
+BenchmarkMacaron_GithubStatic    1000000          2105 ns/op         752 B/op          8 allocs/op
+BenchmarkMartini_GithubStatic     100000         18156 ns/op         832 B/op         11 allocs/op
+BenchmarkPat_GithubStatic     200000         10629 ns/op        3648 B/op         76 allocs/op
+BenchmarkRevel_GithubStatic   300000          4987 ns/op        1288 B/op         25 allocs/op
+BenchmarkRivet_GithubStatic  5000000           393 ns/op         112 B/op          2 allocs/op
+BenchmarkTango_GithubStatic  1000000          1042 ns/op         320 B/op          8 allocs/op
+BenchmarkTigerTonic_GithubStatic     5000000           281 ns/op          48 B/op          1 allocs/op
+BenchmarkTraffic_GithubStatic      50000         37404 ns/op       18920 B/op        149 allocs/op
+BenchmarkVulcan_GithubStatic     1000000          1131 ns/op          98 B/op          3 allocs/op
+BenchmarkZeus_GithubStatic     50000         26059 ns/op        7344 B/op        136 allocs/op
 
-BenchmarkBeego_GithubParam             50000      44645 ns/op        2973 B/op       50 allocs/op
-BenchmarkDenco_GithubParam           5000000        643 ns/op         115 B/op        3 allocs/op
-BenchmarkGocraftWeb_GithubParam      1000000       1855 ns/op         750 B/op       10 allocs/op
-BenchmarkGoji_GithubParam            1000000       1314 ns/op         340 B/op        2 allocs/op
-BenchmarkGoJsonRest_GithubParam       200000       8427 ns/op        2159 B/op       32 allocs/op
-BenchmarkGorillaMux_GithubParam       200000      11485 ns/op         813 B/op        7 allocs/op
-BenchmarkHttpRouter_GithubParam      5000000        304 ns/op          97 B/op        1 allocs/op
-BenchmarkHttpTreeMux_GithubParam     2000000        770 ns/op         340 B/op        2 allocs/op
-BenchmarkKocha_GithubParam           5000000        754 ns/op         132 B/op        4 allocs/op
-BenchmarkMartini_GithubParam          100000      22637 ns/op        1284 B/op       12 allocs/op
-BenchmarkPat_GithubParam              500000       7319 ns/op        2538 B/op       44 allocs/op
-BenchmarkTigerTonic_GithubParam       500000       4722 ns/op        1467 B/op       26 allocs/op
-BenchmarkTraffic_GithubParam          100000      18700 ns/op        7076 B/op       58 allocs/op
+BenchmarkAce_GithubParam     5000000           356 ns/op          96 B/op          1 allocs/op
+BenchmarkBear_GithubParam    1000000          1724 ns/op         560 B/op          6 allocs/op
+BenchmarkBeego_GithubParam   1000000          2457 ns/op         784 B/op         11 allocs/op
+BenchmarkBone_GithubParam     300000          5368 ns/op        1456 B/op         16 allocs/op
+BenchmarkDenco_GithubParam   3000000           447 ns/op         128 B/op          1 allocs/op
+BenchmarkGin_GithubParam     5000000           374 ns/op          96 B/op          1 allocs/op
+BenchmarkGocraftWeb_GithubParam  1000000          1843 ns/op         720 B/op         10 allocs/op
+BenchmarkGoji_GithubParam    1000000          1229 ns/op         336 B/op          2 allocs/op
+BenchmarkGoJsonRest_GithubParam    50000         33013 ns/op        4368 B/op         99 allocs/op
+BenchmarkGoRestful_GithubParam     50000         33528 ns/op         568 B/op         16 allocs/op
+BenchmarkGorillaMux_GithubParam   200000         11515 ns/op         816 B/op          9 allocs/op
+BenchmarkHttpRouter_GithubParam  5000000           291 ns/op          96 B/op          1 allocs/op
+BenchmarkHttpTreeMux_GithubParam     2000000           760 ns/op         336 B/op          2 allocs/op
+BenchmarkKocha_GithubParam   2000000           734 ns/op         128 B/op          5 allocs/op
+BenchmarkMacaron_GithubParam     1000000          3211 ns/op        1168 B/op         12 allocs/op
+BenchmarkMartini_GithubParam      100000         23790 ns/op        1184 B/op         12 allocs/op
+BenchmarkPat_GithubParam      200000          7109 ns/op        2480 B/op         56 allocs/op
+BenchmarkRevel_GithubParam    200000          6261 ns/op        1784 B/op         30 allocs/op
+BenchmarkRivet_GithubParam   1000000          1273 ns/op         480 B/op          6 allocs/op
+BenchmarkTango_GithubParam    300000          6220 ns/op        2240 B/op         48 allocs/op
+BenchmarkTigerTonic_GithubParam   300000          4912 ns/op        1440 B/op         28 allocs/op
+BenchmarkTraffic_GithubParam      100000         16620 ns/op        6024 B/op         55 allocs/op
+BenchmarkVulcan_GithubParam  1000000          1845 ns/op          98 B/op          3 allocs/op
+BenchmarkZeus_GithubParam     100000         21205 ns/op        7496 B/op        100 allocs/op
 
-BenchmarkBeego_GithubAll                 100   23430165 ns/op      502614 B/op     9871 allocs/op
-BenchmarkDenco_GithubAll               10000     120365 ns/op       21219 B/op      506 allocs/op
-BenchmarkGocraftWeb_GithubAll           5000     358982 ns/op      139091 B/op     1903 allocs/op
-BenchmarkGoji_GithubAll                 5000     604522 ns/op       56896 B/op      340 allocs/op
-BenchmarkGoJsonRest_GithubAll           1000    1645794 ns/op      404222 B/op     6303 allocs/op
-BenchmarkGorillaMux_GithubAll            500    6634737 ns/op      152277 B/op     1402 allocs/op
-BenchmarkHttpRouter_GithubAll          50000      51138 ns/op       14039 B/op      168 allocs/op
-BenchmarkHttpTreeMux_GithubAll         10000     132507 ns/op       56907 B/op      340 allocs/op
-BenchmarkKocha_GithubAll               10000     143398 ns/op       24117 B/op      676 allocs/op
-BenchmarkMartini_GithubAll               200    9802351 ns/op      258349 B/op     2713 allocs/op
-BenchmarkPat_GithubAll                   500    4154815 ns/op     1539081 B/op    24970 allocs/op
-BenchmarkTigerTonic_GithubAll           2000     920839 ns/op      247085 B/op     5171 allocs/op
-BenchmarkTraffic_GithubAll               200    8087393 ns/op     3143039 B/op    23958 allocs/op
+BenchmarkAce_GithubAll     20000         63741 ns/op       13792 B/op        167 allocs/op
+BenchmarkBear_GithubAll     5000        323455 ns/op       97840 B/op       1146 allocs/op
+BenchmarkBeego_GithubAll        3000        468911 ns/op      146272 B/op       2092 allocs/op
+BenchmarkBone_GithubAll     1000       2172496 ns/op      648016 B/op       8119 allocs/op
+BenchmarkDenco_GithubAll       20000         78482 ns/op       20224 B/op        167 allocs/op
+BenchmarkGin_GithubAll     20000         68553 ns/op       13792 B/op        167 allocs/op
+BenchmarkGocraftWeb_GithubAll       5000        362107 ns/op      133280 B/op       1889 allocs/op
+BenchmarkGoji_GithubAll     3000        557240 ns/op       56113 B/op        334 allocs/op
+BenchmarkGoJsonRest_GithubAll        200       7028115 ns/op      860715 B/op      19983 allocs/op
+BenchmarkGoRestful_GithubAll         200       8203040 ns/op      598107 B/op       7152 allocs/op
+BenchmarkGorillaMux_GithubAll        200       6705367 ns/op      153137 B/op       1791 allocs/op
+BenchmarkHttpRouter_GithubAll      30000         51046 ns/op       13792 B/op        167 allocs/op
+BenchmarkHttpTreeMux_GithubAll     10000        130105 ns/op       56112 B/op        334 allocs/op
+BenchmarkKocha_GithubAll       10000        138286 ns/op       23304 B/op        843 allocs/op
+BenchmarkMacaron_GithubAll      2000        692800 ns/op      224960 B/op       2315 allocs/op
+BenchmarkMartini_GithubAll       100      11379839 ns/op      237952 B/op       2686 allocs/op
+BenchmarkPat_GithubAll       300       3915465 ns/op     1504101 B/op      32222 allocs/op
+BenchmarkRevel_GithubAll        2000       1222445 ns/op      345553 B/op       5918 allocs/op
+BenchmarkRivet_GithubAll       10000        235504 ns/op       84272 B/op       1079 allocs/op
+BenchmarkTango_GithubAll         500       3395497 ns/op     1338664 B/op      27736 allocs/op
+BenchmarkTigerTonic_GithubAll       2000        938041 ns/op      241088 B/op       6052 allocs/op
+BenchmarkTraffic_GithubAll       200       7263268 ns/op     2664762 B/op      22390 allocs/op
+BenchmarkVulcan_GithubAll       5000        285455 ns/op       19894 B/op        609 allocs/op
+BenchmarkZeus_GithubAll      200       8170547 ns/op     2755680 B/op      39483 allocs/op
 ```
 
 ### [Google+](https://developers.google.com/+/api/latest/)
@@ -297,61 +444,105 @@ BenchmarkTraffic_GithubAll               200    8087393 ns/op     3143039 B/op  
 Last but not least the Google+ API, consisting of 13 routes. In reality this is just a subset of a much larger API.
 
 ```
-BenchmarkBeego_GPlusStatic           1000000       2321 ns/op         808 B/op       11 allocs/op
-BenchmarkDenco_GPlusStatic          50000000         37.2 ns/op         0 B/op        0 allocs/op
-BenchmarkGocraftWeb_GPlusStatic      2000000        862 ns/op         312 B/op        6 allocs/op
-BenchmarkGoji_GPlusStatic           10000000        270 ns/op           0 B/op        0 allocs/op
-BenchmarkGoJsonRest_GPlusStatic       500000       5827 ns/op        1136 B/op       25 allocs/op
-BenchmarkGorillaMux_GPlusStatic      1000000       1793 ns/op         456 B/op        6 allocs/op
-BenchmarkHttpRouter_GPlusStatic     50000000         34.6 ns/op         0 B/op        0 allocs/op
-BenchmarkHttpTreeMux_GPlusStatic    50000000         35.4 ns/op         0 B/op        0 allocs/op
-BenchmarkKocha_GPlusStatic          50000000         63.8 ns/op         0 B/op        0 allocs/op
-BenchmarkMartini_GPlusStatic          500000       4887 ns/op         927 B/op       11 allocs/op
-BenchmarkPat_GPlusStatic             5000000        336 ns/op          98 B/op        2 allocs/op
-BenchmarkTigerTonic_GPlusStatic     10000000        186 ns/op          33 B/op        1 allocs/op
-BenchmarkTraffic_GPlusStatic          500000       3350 ns/op        1503 B/op       18 allocs/op
+BenchmarkAce_GPlusStatic    20000000            94.0 ns/op         0 B/op          0 allocs/op
+BenchmarkBear_GPlusStatic    3000000           562 ns/op         136 B/op          4 allocs/op
+BenchmarkBeego_GPlusStatic   1000000          1123 ns/op         352 B/op          7 allocs/op
+BenchmarkBone_GPlusStatic   10000000           154 ns/op          32 B/op          1 allocs/op
+BenchmarkDenco_GPlusStatic  30000000            38.0 ns/op         0 B/op          0 allocs/op
+BenchmarkGin_GPlusStatic    20000000           107 ns/op           0 B/op          0 allocs/op
+BenchmarkGocraftWeb_GPlusStatic  2000000           824 ns/op         288 B/op          6 allocs/op
+BenchmarkGoji_GPlusStatic   10000000           220 ns/op           0 B/op          0 allocs/op
+BenchmarkGoJsonRest_GPlusStatic    50000         30572 ns/op        3648 B/op         95 allocs/op
+BenchmarkGoRestful_GPlusStatic    200000          6973 ns/op        1736 B/op         28 allocs/op
+BenchmarkGorillaMux_GPlusStatic  1000000          1911 ns/op         464 B/op          8 allocs/op
+BenchmarkHttpRouter_GPlusStatic 50000000            34.2 ns/op         0 B/op          0 allocs/op
+BenchmarkHttpTreeMux_GPlusStatic    50000000            36.8 ns/op         0 B/op          0 allocs/op
+BenchmarkKocha_GPlusStatic  20000000            61.1 ns/op         0 B/op          0 allocs/op
+BenchmarkMacaron_GPlusStatic     1000000          2040 ns/op         736 B/op          8 allocs/op
+BenchmarkMartini_GPlusStatic      500000          4339 ns/op         832 B/op         11 allocs/op
+BenchmarkPat_GPlusStatic     5000000           323 ns/op          96 B/op          2 allocs/op
+BenchmarkRevel_GPlusStatic    500000          4959 ns/op        1272 B/op         25 allocs/op
+BenchmarkRivet_GPlusStatic   5000000           351 ns/op         112 B/op          2 allocs/op
+BenchmarkTango_GPlusStatic   1000000          1004 ns/op         320 B/op          8 allocs/op
+BenchmarkTigerTonic_GPlusStatic 10000000           173 ns/op          32 B/op          1 allocs/op
+BenchmarkTraffic_GPlusStatic     1000000          2546 ns/op        1208 B/op         16 allocs/op
+BenchmarkVulcan_GPlusStatic  2000000           710 ns/op          98 B/op          3 allocs/op
+BenchmarkZeus_GPlusStatic    5000000           266 ns/op          48 B/op          2 allocs/op
 
-BenchmarkBeego_GPlusParam             200000       7657 ns/op        1231 B/op       16 allocs/op
-BenchmarkDenco_GPlusParam            5000000        365 ns/op          50 B/op        2 allocs/op
-BenchmarkGocraftWeb_GPlusParam       1000000       1519 ns/op         684 B/op        9 allocs/op
-BenchmarkGoji_GPlusParam             2000000        889 ns/op         340 B/op        2 allocs/op
-BenchmarkGoJsonRest_GPlusParam        500000       7388 ns/op        1806 B/op       29 allocs/op
-BenchmarkGorillaMux_GPlusParam        500000       4040 ns/op         780 B/op        7 allocs/op
-BenchmarkHttpRouter_GPlusParam      10000000        203 ns/op          65 B/op        1 allocs/op
-BenchmarkHttpTreeMux_GPlusParam      5000000        638 ns/op         340 B/op        2 allocs/op
-BenchmarkKocha_GPlusParam            5000000        444 ns/op          58 B/op        2 allocs/op
-BenchmarkMartini_GPlusParam           200000       8672 ns/op        1251 B/op       12 allocs/op
-BenchmarkPat_GPlusParam              1000000       1895 ns/op         719 B/op       12 allocs/op
-BenchmarkTigerTonic_GPlusParam       1000000       3166 ns/op        1085 B/op       18 allocs/op
-BenchmarkTraffic_GPlusParam           500000       5369 ns/op        2030 B/op       22 allocs/op
+BenchmarkAce_GPlusParam  5000000           251 ns/op          64 B/op          1 allocs/op
+BenchmarkBear_GPlusParam     1000000          1301 ns/op         512 B/op          6 allocs/op
+BenchmarkBeego_GPlusParam    1000000          2068 ns/op         720 B/op         10 allocs/op
+BenchmarkBone_GPlusParam     2000000           874 ns/op         384 B/op          3 allocs/op
+BenchmarkDenco_GPlusParam    5000000           260 ns/op          64 B/op          1 allocs/op
+BenchmarkGin_GPlusParam  5000000           272 ns/op          64 B/op          1 allocs/op
+BenchmarkGocraftWeb_GPlusParam   1000000          1507 ns/op         656 B/op          9 allocs/op
+BenchmarkGoji_GPlusParam     2000000           835 ns/op         336 B/op          2 allocs/op
+BenchmarkGoJsonRest_GPlusParam     50000         33086 ns/op        4240 B/op         98 allocs/op
+BenchmarkGoRestful_GPlusParam     300000          6108 ns/op         632 B/op         18 allocs/op
+BenchmarkGorillaMux_GPlusParam    500000          4104 ns/op         784 B/op          9 allocs/op
+BenchmarkHttpRouter_GPlusParam  10000000           192 ns/op          64 B/op          1 allocs/op
+BenchmarkHttpTreeMux_GPlusParam  2000000           611 ns/op         336 B/op          2 allocs/op
+BenchmarkKocha_GPlusParam    5000000           405 ns/op          56 B/op          3 allocs/op
+BenchmarkMacaron_GPlusParam  1000000          2800 ns/op        1104 B/op         11 allocs/op
+BenchmarkMartini_GPlusParam   200000          8656 ns/op        1152 B/op         12 allocs/op
+BenchmarkPat_GPlusParam  1000000          1870 ns/op         704 B/op         14 allocs/op
+BenchmarkRevel_GPlusParam     300000          5753 ns/op        1704 B/op         28 allocs/op
+BenchmarkRivet_GPlusParam    2000000          1008 ns/op         464 B/op          5 allocs/op
+BenchmarkTango_GPlusParam    1000000          1880 ns/op         712 B/op         13 allocs/op
+BenchmarkTigerTonic_GPlusParam   1000000          3177 ns/op        1064 B/op         19 allocs/op
+BenchmarkTraffic_GPlusParam   300000          5503 ns/op        2000 B/op         23 allocs/op
+BenchmarkVulcan_GPlusParam   1000000          1029 ns/op          98 B/op          3 allocs/op
+BenchmarkZeus_GPlusParam     1000000          1178 ns/op         440 B/op          6 allocs/op
 
-BenchmarkBeego_GPlus2Params           200000       9999 ns/op        1293 B/op       16 allocs/op
-BenchmarkDenco_GPlus2Params          5000000        618 ns/op         115 B/op        3 allocs/op
-BenchmarkGocraftWeb_GPlus2Params     1000000       1860 ns/op         750 B/op       10 allocs/op
-BenchmarkGoji_GPlus2Params           1000000       1296 ns/op         340 B/op        2 allocs/op
-BenchmarkGoJsonRest_GPlus2Params      200000       8516 ns/op        2178 B/op       32 allocs/op
-BenchmarkGorillaMux_GPlus2Params      200000       9007 ns/op         812 B/op        7 allocs/op
-BenchmarkHttpRouter_GPlus2Params    10000000        246 ns/op          65 B/op        1 allocs/op
-BenchmarkHttpTreeMux_GPlus2Params    2000000        751 ns/op         340 B/op        2 allocs/op
-BenchmarkKocha_GPlus2Params          5000000        744 ns/op         132 B/op        4 allocs/op
-BenchmarkMartini_GPlus2Params         100000      27700 ns/op        1382 B/op       16 allocs/op
-BenchmarkPat_GPlus2Params             500000       5981 ns/op        2347 B/op       34 allocs/op
-BenchmarkTigerTonic_GPlus2Params      500000       5076 ns/op        1561 B/op       27 allocs/op
-BenchmarkTraffic_GPlus2Params         200000      12711 ns/op        3599 B/op       34 allocs/op
+BenchmarkAce_GPlus2Params    5000000           297 ns/op          64 B/op          1 allocs/op
+BenchmarkBear_GPlus2Params   1000000          1701 ns/op         576 B/op          6 allocs/op
+BenchmarkBeego_GPlus2Params  1000000          2504 ns/op         784 B/op         11 allocs/op
+BenchmarkBone_GPlus2Params   1000000          2552 ns/op         736 B/op          7 allocs/op
+BenchmarkDenco_GPlus2Params  5000000           345 ns/op          64 B/op          1 allocs/op
+BenchmarkGin_GPlus2Params    5000000           302 ns/op          64 B/op          1 allocs/op
+BenchmarkGocraftWeb_GPlus2Params     1000000          1831 ns/op         720 B/op         10 allocs/op
+BenchmarkGoji_GPlus2Params   1000000          1190 ns/op         336 B/op          2 allocs/op
+BenchmarkGoJsonRest_GPlus2Params       50000         32878 ns/op        4384 B/op         99 allocs/op
+BenchmarkGoRestful_GPlus2Params   200000          7730 ns/op         632 B/op         18 allocs/op
+BenchmarkGorillaMux_GPlus2Params      200000          9201 ns/op         816 B/op          9 allocs/op
+BenchmarkHttpRouter_GPlus2Params    10000000           232 ns/op          64 B/op          1 allocs/op
+BenchmarkHttpTreeMux_GPlus2Params    2000000           739 ns/op         336 B/op          2 allocs/op
+BenchmarkKocha_GPlus2Params  2000000           693 ns/op         128 B/op          5 allocs/op
+BenchmarkMacaron_GPlus2Params    1000000          3209 ns/op        1168 B/op         12 allocs/op
+BenchmarkMartini_GPlus2Params      50000         28563 ns/op        1280 B/op         16 allocs/op
+BenchmarkPat_GPlus2Params     300000          5871 ns/op        2304 B/op         41 allocs/op
+BenchmarkRevel_GPlus2Params   300000          6282 ns/op        1800 B/op         30 allocs/op
+BenchmarkRivet_GPlus2Params  1000000          1159 ns/op         480 B/op          6 allocs/op
+BenchmarkTango_GPlus2Params   300000          5111 ns/op        2136 B/op         36 allocs/op
+BenchmarkTigerTonic_GPlus2Params      300000          5196 ns/op        1528 B/op         28 allocs/op
+BenchmarkTraffic_GPlus2Params     200000         12093 ns/op        3312 B/op         34 allocs/op
+BenchmarkVulcan_GPlus2Params     1000000          1483 ns/op          98 B/op          3 allocs/op
+BenchmarkZeus_GPlus2Params    200000          7680 ns/op        2864 B/op         37 allocs/op
 
-BenchmarkBeego_GPlusAll                10000     113601 ns/op       15897 B/op      217 allocs/op
-BenchmarkDenco_GPlusAll               500000       5761 ns/op         880 B/op       27 allocs/op
-BenchmarkGocraftWeb_GPlusAll          100000      20527 ns/op        8513 B/op      116 allocs/op
-BenchmarkGoji_GPlusAll                200000      12312 ns/op        3746 B/op       22 allocs/op
-BenchmarkGoJsonRest_GPlusAll           20000      99250 ns/op       23871 B/op      386 allocs/op
-BenchmarkGorillaMux_GPlusAll           50000      63046 ns/op        9655 B/op       90 allocs/op
-BenchmarkHttpRouter_GPlusAll         1000000       2513 ns/op         655 B/op       11 allocs/op
-BenchmarkHttpTreeMux_GPlusAll         500000       7706 ns/op        3748 B/op       22 allocs/op
-BenchmarkKocha_GPlusAll               500000       6858 ns/op        1017 B/op       35 allocs/op
-BenchmarkMartini_GPlusAll              10000     155402 ns/op       16368 B/op      179 allocs/op
-BenchmarkPat_GPlusAll                  50000      47397 ns/op       17270 B/op      302 allocs/op
-BenchmarkTigerTonic_GPlusAll           50000      49864 ns/op       15160 B/op      311 allocs/op
-BenchmarkTraffic_GPlusAll              10000     108007 ns/op       41779 B/op      430 allocs/op
+BenchmarkAce_GPlusAll     500000          3312 ns/op         640 B/op         11 allocs/op
+BenchmarkBear_GPlusAll    100000         16969 ns/op        6168 B/op         74 allocs/op
+BenchmarkBeego_GPlusAll    50000         26293 ns/op        8976 B/op        129 allocs/op
+BenchmarkBone_GPlusAll    100000         21740 ns/op        6992 B/op         76 allocs/op
+BenchmarkDenco_GPlusAll   500000          3718 ns/op         672 B/op         11 allocs/op
+BenchmarkGin_GPlusAll     500000          3484 ns/op         640 B/op         11 allocs/op
+BenchmarkGocraftWeb_GPlusAll      100000         19972 ns/op        8144 B/op        116 allocs/op
+BenchmarkGoji_GPlusAll    200000         11510 ns/op        3696 B/op         22 allocs/op
+BenchmarkGoJsonRest_GPlusAll        5000        421075 ns/op       54499 B/op       1274 allocs/op
+BenchmarkGoRestful_GPlusAll    10000        120138 ns/op       26264 B/op        404 allocs/op
+BenchmarkGorillaMux_GPlusAll       20000         65963 ns/op        9712 B/op        115 allocs/op
+BenchmarkHttpRouter_GPlusAll     1000000          2441 ns/op         640 B/op         11 allocs/op
+BenchmarkHttpTreeMux_GPlusAll     200000          7449 ns/op        3696 B/op         22 allocs/op
+BenchmarkKocha_GPlusAll   300000          6425 ns/op         976 B/op         43 allocs/op
+BenchmarkMacaron_GPlusAll      50000         36082 ns/op       13968 B/op        142 allocs/op
+BenchmarkMartini_GPlusAll      10000        155220 ns/op       15072 B/op        178 allocs/op
+BenchmarkPat_GPlusAll      30000         46035 ns/op       16880 B/op        343 allocs/op
+BenchmarkRevel_GPlusAll    20000         77560 ns/op       21656 B/op        368 allocs/op
+BenchmarkRivet_GPlusAll   200000         13012 ns/op        5408 B/op         64 allocs/op
+BenchmarkTango_GPlusAll    50000         40046 ns/op       15624 B/op        280 allocs/op
+BenchmarkTigerTonic_GPlusAll       30000         50101 ns/op       14800 B/op        320 allocs/op
+BenchmarkTraffic_GPlusAll      10000        100134 ns/op       37760 B/op        421 allocs/op
+BenchmarkVulcan_GPlusAll      100000         14525 ns/op        1274 B/op         39 allocs/op
+BenchmarkZeus_GPlusAll     30000         53868 ns/op       18440 B/op        268 allocs/op
 ```
 
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -71,6 +71,12 @@ func BenchmarkAce_Param(b *testing.B) {
 	r, _ := http.NewRequest("GET", "/user/gordon", nil)
 	benchRequest(b, router, r)
 }
+func BenchmarkBear_Param(b *testing.B) {
+	router := loadBearSingle("GET", "/user/{name}", bearHandler)
+
+	r, _ := http.NewRequest("GET", "/user/gordon", nil)
+	benchRequest(b, router, r)
+}
 func BenchmarkBeego_Param(b *testing.B) {
 	router := loadBeegoSingle("GET", "/user/:name", beegoHandler)
 
@@ -215,6 +221,12 @@ const fiveRoute = "/test/test/test/test/test"
 
 func BenchmarkAce_Param5(b *testing.B) {
 	router := loadAceSingle("GET", fiveColon, aceHandle)
+
+	r, _ := http.NewRequest("GET", fiveRoute, nil)
+	benchRequest(b, router, r)
+}
+func BenchmarkBear_Param5(b *testing.B) {
+	router := loadBearSingle("GET", fiveBrace, bearHandler)
 
 	r, _ := http.NewRequest("GET", fiveRoute, nil)
 	benchRequest(b, router, r)
@@ -367,6 +379,12 @@ func BenchmarkAce_Param20(b *testing.B) {
 	r, _ := http.NewRequest("GET", twentyRoute, nil)
 	benchRequest(b, router, r)
 }
+func BenchmarkBear_Param20(b *testing.B) {
+	router := loadBearSingle("GET", twentyBrace, bearHandler)
+
+	r, _ := http.NewRequest("GET", twentyRoute, nil)
+	benchRequest(b, router, r)
+}
 func BenchmarkBeego_Param20(b *testing.B) {
 	router := loadBeegoSingle("GET", twentyColon, beegoHandler)
 
@@ -507,6 +525,12 @@ func BenchmarkZeus_Param20(b *testing.B) {
 // Route with Param and write
 func BenchmarkAce_ParamWrite(b *testing.B) {
 	router := loadAceSingle("GET", "/user/:name", aceHandleWrite)
+
+	r, _ := http.NewRequest("GET", "/user/gordon", nil)
+	benchRequest(b, router, r)
+}
+func BenchmarkBear_ParamWrite(b *testing.B) {
+	router := loadBearSingle("GET", "/user/{name}", bearHandlerWrite)
 
 	r, _ := http.NewRequest("GET", "/user/gordon", nil)
 	benchRequest(b, router, r)

--- a/github_test.go
+++ b/github_test.go
@@ -275,6 +275,7 @@ var githubAPI = []route{
 
 var (
 	githubAce         http.Handler
+	githubBear        http.Handler
 	githubBeego       http.Handler
 	githubBone        http.Handler
 	githubDenco       http.Handler
@@ -304,6 +305,9 @@ func init() {
 
 	calcMem("Ace", func() {
 		githubAce = loadAce(githubAPI)
+	})
+	calcMem("Bear", func() {
+		githubBear = loadBear(githubAPI)
 	})
 	calcMem("Beego", func() {
 		githubBeego = loadBeego(githubAPI)
@@ -379,6 +383,10 @@ func init() {
 func BenchmarkAce_GithubStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/user/repos", nil)
 	benchRequest(b, githubAce, req)
+}
+func BenchmarkBear_GithubStatic(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/user/repos", nil)
+	benchRequest(b, githubBear, req)
 }
 func BenchmarkBeego_GithubStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/user/repos", nil)
@@ -474,6 +482,10 @@ func BenchmarkAce_GithubParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/repos/julienschmidt/httprouter/stargazers", nil)
 	benchRequest(b, githubAce, req)
 }
+func BenchmarkBear_GithubParam(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/repos/julienschmidt/httprouter/stargazers", nil)
+	benchRequest(b, githubBear, req)
+}
 func BenchmarkBeego_GithubParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/repos/julienschmidt/httprouter/stargazers", nil)
 	benchRequest(b, githubBeego, req)
@@ -566,6 +578,9 @@ func BenchmarkZeus_GithubParam(b *testing.B) {
 // All routes
 func BenchmarkAce_GithubAll(b *testing.B) {
 	benchRoutes(b, githubAce, githubAPI)
+}
+func BenchmarkBear_GithubAll(b *testing.B) {
+	benchRoutes(b, githubBear, githubAPI)
 }
 func BenchmarkBeego_GithubAll(b *testing.B) {
 	benchRoutes(b, githubBeego, githubAPI)

--- a/gplus_test.go
+++ b/gplus_test.go
@@ -37,6 +37,7 @@ var gplusAPI = []route{
 
 var (
 	gplusAce         http.Handler
+	gplusBear        http.Handler
 	gplusBeego       http.Handler
 	gplusBone        http.Handler
 	gplusDenco       http.Handler
@@ -66,6 +67,9 @@ func init() {
 
 	calcMem("Ace", func() {
 		gplusAce = loadAce(gplusAPI)
+	})
+	calcMem("Bear", func() {
+		gplusBear = loadBear(gplusAPI)
 	})
 	calcMem("Beego", func() {
 		gplusBeego = loadBeego(gplusAPI)
@@ -141,6 +145,10 @@ func init() {
 func BenchmarkAce_GPlusStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people", nil)
 	benchRequest(b, gplusAce, req)
+}
+func BenchmarkBear_GPlusStatic(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/people", nil)
+	benchRequest(b, gplusBear, req)
 }
 func BenchmarkBeego_GPlusStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people", nil)
@@ -236,6 +244,10 @@ func BenchmarkAce_GPlusParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people/118051310819094153327", nil)
 	benchRequest(b, gplusAce, req)
 }
+func BenchmarkBear_GPlusParam(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/people/118051310819094153327", nil)
+	benchRequest(b, gplusBear, req)
+}
 func BenchmarkBeego_GPlusParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people/118051310819094153327", nil)
 	benchRequest(b, gplusBeego, req)
@@ -330,6 +342,10 @@ func BenchmarkAce_GPlus2Params(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people/118051310819094153327/activities/123456789", nil)
 	benchRequest(b, gplusAce, req)
 }
+func BenchmarkBear_GPlus2Params(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/people/118051310819094153327/activities/123456789", nil)
+	benchRequest(b, gplusBear, req)
+}
 func BenchmarkBeego_GPlus2Params(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people/118051310819094153327/activities/123456789", nil)
 	benchRequest(b, gplusBeego, req)
@@ -422,6 +438,9 @@ func BenchmarkZeus_GPlus2Params(b *testing.B) {
 // All Routes
 func BenchmarkAce_GPlusAll(b *testing.B) {
 	benchRoutes(b, gplusAce, gplusAPI)
+}
+func BenchmarkBear_GPlusAll(b *testing.B) {
+	benchRoutes(b, gplusBear, gplusAPI)
 }
 func BenchmarkBeego_GPlusAll(b *testing.B) {
 	benchRoutes(b, gplusBeego, gplusAPI)

--- a/parse_test.go
+++ b/parse_test.go
@@ -57,6 +57,7 @@ var parseAPI = []route{
 
 var (
 	parseAce         http.Handler
+	parseBear        http.Handler
 	parseBeego       http.Handler
 	parseBone        http.Handler
 	parseDenco       http.Handler
@@ -86,6 +87,9 @@ func init() {
 
 	calcMem("Ace", func() {
 		parseAce = loadAce(parseAPI)
+	})
+	calcMem("Bear", func() {
+		parseBear = loadBear(parseAPI)
 	})
 	calcMem("Beego", func() {
 		parseBeego = loadBeego(parseAPI)
@@ -161,6 +165,10 @@ func init() {
 func BenchmarkAce_ParseStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/users", nil)
 	benchRequest(b, parseAce, req)
+}
+func BenchmarkBear_ParseStatic(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/1/users", nil)
+	benchRequest(b, parseBear, req)
 }
 func BenchmarkBeego_ParseStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/users", nil)
@@ -256,6 +264,10 @@ func BenchmarkAce_ParseParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/classes/go", nil)
 	benchRequest(b, parseAce, req)
 }
+func BenchmarkBear_ParseParam(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/1/classes/go", nil)
+	benchRequest(b, parseBear, req)
+}
 func BenchmarkBeego_ParseParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/classes/go", nil)
 	benchRequest(b, parseBeego, req)
@@ -350,6 +362,10 @@ func BenchmarkAce_Parse2Params(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/classes/go/123456789", nil)
 	benchRequest(b, parseAce, req)
 }
+func BenchmarkBear_Parse2Params(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/1/classes/go/123456789", nil)
+	benchRequest(b, parseBear, req)
+}
 func BenchmarkBeego_Parse2Params(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/classes/go/123456789", nil)
 	benchRequest(b, parseBeego, req)
@@ -442,6 +458,9 @@ func BenchmarkZeus_Parse2Params(b *testing.B) {
 // All Routes
 func BenchmarkAce_ParseAll(b *testing.B) {
 	benchRoutes(b, parseAce, parseAPI)
+}
+func BenchmarkBear_ParseAll(b *testing.B) {
+	benchRoutes(b, parseBeego, parseAPI)
 }
 func BenchmarkBeego_ParseAll(b *testing.B) {
 	benchRoutes(b, parseBeego, parseAPI)

--- a/routers.go
+++ b/routers.go
@@ -42,6 +42,7 @@ import (
 	"github.com/revel/revel"
 	"github.com/robfig/pathtree"
 	"github.com/typepress/rivet"
+	"github.com/ursiform/bear"
 	goji "github.com/zenazn/goji/web"
 )
 
@@ -109,6 +110,37 @@ func loadAceSingle(method, path string, handle ace.HandlerFunc) http.Handler {
 	return router
 }
 
+// bear
+func bearHandler(_ http.ResponseWriter, _ *http.Request, ctx *bear.Context) {}
+
+func bearHandlerWrite(res http.ResponseWriter, req *http.Request, ctx *bear.Context) {
+	res.Write([]byte(ctx.Params["name"]))
+}
+func loadBear(routes []route) http.Handler {
+	router := bear.New()
+	re := regexp.MustCompile(":([^/]*)")
+	for _, route := range routes {
+		switch route.method {
+		case "GET", "POST", "PUT", "PATCH", "DELETE":
+			router.On(route.method, re.ReplaceAllString(route.path, "{$1}"), bearHandler)
+		default:
+			panic("Unknown HTTP method: " + route.method)
+		}
+	}
+	return router
+}
+
+func loadBearSingle(method string, path string, handler bear.HandlerFunc) http.Handler {
+	router := bear.New()
+	switch method {
+	case "GET", "POST", "PUT", "PATCH", "DELETE":
+		router.On(method, path, handler)
+	default:
+		panic("Unknown HTTP method: " + method)
+	}
+	return router
+}
+
 // beego
 func beegoHandler(ctx *context.Context) {}
 
@@ -138,7 +170,7 @@ func loadBeego(routes []route) http.Handler {
 		case "DELETE":
 			app.Delete(route.path, beegoHandler)
 		default:
-			panic("Unknow HTTP method: " + route.method)
+			panic("Unknown HTTP method: " + route.method)
 		}
 	}
 	return app
@@ -158,7 +190,7 @@ func loadBeegoSingle(method, path string, handler beego.FilterFunc) http.Handler
 	case "DELETE":
 		app.Delete(path, handler)
 	default:
-		panic("Unknow HTTP method: " + method)
+		panic("Unknown HTTP method: " + method)
 	}
 	return app
 }
@@ -179,7 +211,7 @@ func loadBone(routes []route) http.Handler {
 		case "DELETE":
 			router.Delete(route.path, http.HandlerFunc(httpHandlerFunc))
 		default:
-			panic("Unknow HTTP method: " + route.method)
+			panic("Unknown HTTP method: " + route.method)
 		}
 	}
 	return router
@@ -199,7 +231,7 @@ func loadBoneSingle(method, path string, handler http.Handler) http.Handler {
 	case "DELETE":
 		router.Delete(path, handler)
 	default:
-		panic("Unknow HTTP method: " + method)
+		panic("Unknown HTTP method: " + method)
 	}
 	return router
 }
@@ -290,7 +322,7 @@ func loadGocraftWeb(routes []route) http.Handler {
 		case "DELETE":
 			router.Delete(route.path, gocraftWebHandler)
 		default:
-			panic("Unknow HTTP method: " + route.method)
+			panic("Unknown HTTP method: " + route.method)
 		}
 	}
 	return router
@@ -310,7 +342,7 @@ func loadGocraftWebSingle(method, path string, handler interface{}) http.Handler
 	case "DELETE":
 		router.Delete(path, handler)
 	default:
-		panic("Unknow HTTP method: " + method)
+		panic("Unknown HTTP method: " + method)
 	}
 	return router
 }
@@ -355,7 +387,7 @@ func loadGojiSingle(method, path string, handler interface{}) http.Handler {
 	case "DELETE":
 		mux.Delete(path, handler)
 	default:
-		panic("Unknow HTTP method: " + method)
+		panic("Unknown HTTP method: " + method)
 	}
 	return mux
 }
@@ -421,7 +453,7 @@ func loadGoRestful(routes []route) http.Handler {
 		case "DELETE":
 			ws.Route(ws.DELETE(route.path).To(goRestfulHandler))
 		default:
-			panic("Unknow HTTP method: " + route.method)
+			panic("Unknown HTTP method: " + route.method)
 		}
 	}
 	wsContainer.Add(ws)
@@ -443,7 +475,7 @@ func loadGoRestfulSingle(method, path string, handler restful.RouteFunction) htt
 	case "DELETE":
 		ws.Route(ws.DELETE(path).To(handler))
 	default:
-		panic("Unknow HTTP method: " + method)
+		panic("Unknown HTTP method: " + method)
 	}
 	wsContainer.Add(ws)
 	return wsContainer
@@ -614,7 +646,7 @@ func loadMacaron(routes []route) http.Handler {
 		case "DELETE":
 			m.Delete(route.path, martiniHandler)
 		default:
-			panic("Unknow HTTP method: " + route.method)
+			panic("Unknown HTTP method: " + route.method)
 		}
 	}
 	return m
@@ -634,7 +666,7 @@ func loadMacaronSingle(method, path string, handler interface{}) http.Handler {
 	case "DELETE":
 		m.Delete(path, handler)
 	default:
-		panic("Unknow HTTP method: " + method)
+		panic("Unknown HTTP method: " + method)
 	}
 	return m
 }
@@ -665,7 +697,7 @@ func loadMartini(routes []route) http.Handler {
 		case "DELETE":
 			router.Delete(route.path, martiniHandler)
 		default:
-			panic("Unknow HTTP method: " + route.method)
+			panic("Unknown HTTP method: " + route.method)
 		}
 	}
 	martini := martini.New()
@@ -687,7 +719,7 @@ func loadMartiniSingle(method, path string, handler interface{}) http.Handler {
 	case "DELETE":
 		router.Delete(path, handler)
 	default:
-		panic("Unknow HTTP method: " + method)
+		panic("Unknown HTTP method: " + method)
 	}
 
 	martini := martini.New()
@@ -713,7 +745,7 @@ func loadPat(routes []route) http.Handler {
 		case "DELETE":
 			m.Del(route.path, http.HandlerFunc(httpHandlerFunc))
 		default:
-			panic("Unknow HTTP method: " + route.method)
+			panic("Unknown HTTP method: " + route.method)
 		}
 	}
 	return m
@@ -731,7 +763,7 @@ func loadPatSingle(method, path string, handler http.Handler) http.Handler {
 	case "DELETE":
 		m.Del(path, handler)
 	default:
-		panic("Unknow HTTP method: " + method)
+		panic("Unknown HTTP method: " + method)
 	}
 	return m
 }
@@ -937,7 +969,7 @@ func loadTraffic(routes []route) http.Handler {
 		case "DELETE":
 			router.Delete(route.path, trafficHandler)
 		default:
-			panic("Unknow HTTP method: " + route.method)
+			panic("Unknown HTTP method: " + route.method)
 		}
 	}
 	return router
@@ -957,7 +989,7 @@ func loadTrafficSingle(method, path string, handler traffic.HttpHandleFunc) http
 	case "DELETE":
 		router.Delete(path, handler)
 	default:
-		panic("Unknow HTTP method: " + method)
+		panic("Unknown HTTP method: " + method)
 	}
 	return router
 }
@@ -1007,7 +1039,7 @@ func loadZeus(routes []route) http.Handler {
 		case "DELETE":
 			m.DELETE(route.path, http.HandlerFunc(httpHandlerFunc))
 		default:
-			panic("Unknow HTTP method: " + route.method)
+			panic("Unknown HTTP method: " + route.method)
 		}
 	}
 	return m
@@ -1025,7 +1057,7 @@ func loadZeusSingle(method, path string, handler http.HandlerFunc) http.Handler 
 	case "DELETE":
 		m.DELETE(path, handler)
 	default:
-		panic("Unknow HTTP method: " + method)
+		panic("Unknown HTTP method: " + method)
 	}
 	return m
 }

--- a/static_test.go
+++ b/static_test.go
@@ -173,6 +173,7 @@ var (
 	staticHttpServeMux http.Handler
 
 	staticAce         http.Handler
+	staticBear        http.Handler
 	staticBeego       http.Handler
 	staticBone        http.Handler
 	staticDenco       http.Handler
@@ -210,6 +211,9 @@ func init() {
 
 	calcMem("Ace", func() {
 		staticAce = loadAce(staticRoutes)
+	})
+	calcMem("Bear", func() {
+		staticBear = loadBear(staticRoutes)
 	})
 	calcMem("Beego", func() {
 		staticBeego = loadBeego(staticRoutes)
@@ -288,6 +292,9 @@ func BenchmarkAce_StaticAll(b *testing.B) {
 }
 func BenchmarkHttpServeMux_StaticAll(b *testing.B) {
 	benchRoutes(b, staticHttpServeMux, staticRoutes)
+}
+func BenchmarkBear_StaticAll(b *testing.B) {
+	benchRoutes(b, staticBear, staticRoutes)
 }
 func BenchmarkBeego_StaticAll(b *testing.B) {
 	benchRoutes(b, staticBeego, staticRoutes)


### PR DESCRIPTION
added ursiform/bear, fixed a typo, updated the README with new benchmark output ...

The overall conclusion has not changed, but it might be worth re-visiting the README since some of these libs have been updated since the original was written. For example, several of them have significantly lower memory footprints than they did in the last commit.