### PR TITLE
Rewrite the Go-Json-Rest benchmark to use the v3 api.

### DIFF
--- a/routers.go
+++ b/routers.go
@@ -367,34 +367,32 @@ func goJsonRestHandlerWrite(w rest.ResponseWriter, req *rest.Request) {
 	io.WriteString(w.(io.Writer), req.PathParam("name"))
 }
 
-func newGoJsonRestResourceHandler() *rest.ResourceHandler {
-	handler := rest.ResourceHandler{
-		EnableRelaxedContentType: true,
-		Logger:            nullLogger,
-		ErrorLogger:       nullLogger,
-		DisableXPoweredBy: true,
-	}
-	return &handler
-}
-
 func loadGoJsonRest(routes []route) http.Handler {
-	handler := newGoJsonRestResourceHandler()
+	api := rest.NewApi()
 	restRoutes := make([]*rest.Route, 0, len(routes))
 	for _, route := range routes {
 		restRoutes = append(restRoutes,
 			&rest.Route{route.method, route.path, goJsonRestHandler},
 		)
 	}
-	handler.SetRoutes(restRoutes...)
-	return handler
+	router, err := rest.MakeRouter(restRoutes...)
+	if err != nil {
+		log.Fatal(err)
+	}
+	api.SetApp(router)
+	return api.MakeHandler()
 }
 
 func loadGoJsonRestSingle(method, path string, hfunc rest.HandlerFunc) http.Handler {
-	handler := newGoJsonRestResourceHandler()
-	handler.SetRoutes(
+	api := rest.NewApi()
+	router, err := rest.MakeRouter(
 		&rest.Route{method, path, hfunc},
 	)
-	return handler
+	if err != nil {
+		log.Fatal(err)
+	}
+	api.SetApp(router)
+	return api.MakeHandler()
 }
 
 // go-restful


### PR DESCRIPTION
Hi!

The v3.0.0 of Go-Json-Rest has been released a few days ago. Here is a small patch to keep these benchmarks up-to-date.

I find them particularly useful, thanks for doing that!

Antoine 