### PR TITLE
Prevent Tango from writing to stdout

### DIFF
--- a/routers.go
+++ b/routers.go
@@ -7,6 +7,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -909,7 +910,7 @@ func initTango() {
 }
 
 func loadTango(routes []route) http.Handler {
-	tg := tango.New()
+	tg := tango.NewWithLog(tango.NewLogger(ioutil.Discard))
 	for _, route := range routes {
 		tg.Route([]string{route.method}, route.path, tangoHandler)
 	}
@@ -917,7 +918,7 @@ func loadTango(routes []route) http.Handler {
 }
 
 func loadTangoSingle(method, path string, handler func(*tango.Context)) http.Handler {
-	tg := tango.New()
+	tg := tango.NewWithLog(tango.NewLogger(ioutil.Discard))
 	tg.Route([]string{method}, path, handler)
 	return tg
 }


### PR DESCRIPTION
Tango initializes itself with a logger to stdout, which gets quite long
during all of the benchmark requests.
https://github.com/lunny/tango/blob/master/tan.go#L199

Instead write to /dev/null (ioutil.Discard).