### PR TITLE
the `echo` handle should match the function declaration.

### DIFF
--- a/routers.go
+++ b/routers.go
@@ -323,16 +323,16 @@ func loadDencoSingle(method, path string, h denco.HandlerFunc) http.Handler {
 }
 
 // Echo
-func echoHandler(c *echo.Context) error {
+func echoHandler(c *echo.Context) *echo.HTTPError {
 	return nil
 }
 
-func echoHandlerWrite(c *echo.Context) error {
+func echoHandlerWrite(c *echo.Context) *echo.HTTPError {
 	io.WriteString(c.Response, c.Param("name"))
 	return nil
 }
 
-func echoHandlerTest(c *echo.Context) error {
+func echoHandlerTest(c *echo.Context) *echo.HTTPError {
 	io.WriteString(c.Response, c.Request.RequestURI)
 	return nil
 }


### PR DESCRIPTION
There will be a panic `panic: echo: unknown handler` after running `go test`.


The reason is the declaration of HandlerFunc is in [echo.go, line 40](https://github.com/labstack/echo/blob/master/echo.go#L40):

```HandlerFunc    func(*Context) *HTTPError```

It will not match the declaration `func(*Context) error` in the test.
