### PR TITLE
add vanilla router to benchmark

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -252,6 +252,12 @@ func BenchmarkTraffic_Param(b *testing.B) {
 	r, _ := http.NewRequest("GET", "/user/gordon", nil)
 	benchRequest(b, router, r)
 }
+func BenchmarkVanilla_Param(b *testing.B) {
+	router := loadVanillaSingle("GET", "/user/:name", http.HandlerFunc(httpHandlerFunc))
+
+	r, _ := http.NewRequest("GET", "/user/gordon", nil)
+	benchRequest(b, router, r)
+}
 func BenchmarkVulcan_Param(b *testing.B) {
 	router := loadVulcanSingle("GET", "/user/:name", vulcanHandler)
 
@@ -422,6 +428,12 @@ func BenchmarkTigerTonic_Param5(b *testing.B) {
 }
 func BenchmarkTraffic_Param5(b *testing.B) {
 	router := loadTrafficSingle("GET", fiveColon, trafficHandler)
+
+	r, _ := http.NewRequest("GET", fiveRoute, nil)
+	benchRequest(b, router, r)
+}
+func BenchmarkVanilla_Param5(b *testing.B) {
+	router := loadVanillaSingle("GET", fiveColon, http.HandlerFunc(httpHandlerFunc))
 
 	r, _ := http.NewRequest("GET", fiveRoute, nil)
 	benchRequest(b, router, r)
@@ -600,6 +612,12 @@ func BenchmarkTraffic_Param20(b *testing.B) {
 	r, _ := http.NewRequest("GET", twentyRoute, nil)
 	benchRequest(b, router, r)
 }
+func BenchmarkVanilla_Param20(b *testing.B) {
+	router := loadVanillaSingle("GET", twentyColon, http.HandlerFunc(httpHandlerFunc))
+
+	r, _ := http.NewRequest("GET", twentyRoute, nil)
+	benchRequest(b, router, r)
+}
 func BenchmarkVulcan_Param20(b *testing.B) {
 	router := loadVulcanSingle("GET", twentyColon, vulcanHandler)
 
@@ -769,6 +787,12 @@ func BenchmarkTigerTonic_ParamWrite(b *testing.B) {
 }
 func BenchmarkTraffic_ParamWrite(b *testing.B) {
 	router := loadTrafficSingle("GET", "/user/:name", trafficHandlerWrite)
+
+	r, _ := http.NewRequest("GET", "/user/gordon", nil)
+	benchRequest(b, router, r)
+}
+func BenchmarkVanilla_ParamWrite(b *testing.B) {
+	router := loadVanillaSingle("GET", "/user/:name", http.HandlerFunc(httpHandlerFunc))
 
 	r, _ := http.NewRequest("GET", "/user/gordon", nil)
 	benchRequest(b, router, r)

--- a/github_test.go
+++ b/github_test.go
@@ -299,6 +299,7 @@ var (
 	githubTango       http.Handler
 	githubTigerTonic  http.Handler
 	githubTraffic     http.Handler
+	githubVanilla     http.Handler
 	githubVulcan      http.Handler
 	// githubZeus        http.Handler
 )
@@ -380,6 +381,9 @@ func init() {
 	})
 	calcMem("Traffic", func() {
 		githubTraffic = loadTraffic(githubAPI)
+	})
+	calcMem("Vanilla", func() {
+		githubVanilla = loadVanilla(githubAPI)
 	})
 	calcMem("Vulcan", func() {
 		githubVulcan = loadVulcan(githubAPI)
@@ -492,6 +496,10 @@ func BenchmarkTraffic_GithubStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/user/repos", nil)
 	benchRequest(b, githubTraffic, req)
 }
+func BenchmarkVanilla_GithubStatic(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/user/repos", nil)
+	benchRequest(b, githubVanilla, req)
+}
 func BenchmarkVulcan_GithubStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/user/repos", nil)
 	benchRequest(b, githubVulcan, req)
@@ -603,6 +611,10 @@ func BenchmarkTraffic_GithubParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/repos/julienschmidt/httprouter/stargazers", nil)
 	benchRequest(b, githubTraffic, req)
 }
+func BenchmarkVanilla_GithubParam(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/repos/julienschmidt/httprouter/stargazers", nil)
+	benchRequest(b, githubVanilla, req)
+}
 func BenchmarkVulcan_GithubParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/repos/julienschmidt/httprouter/stargazers", nil)
 	benchRequest(b, githubVulcan, req)
@@ -688,6 +700,9 @@ func BenchmarkTigerTonic_GithubAll(b *testing.B) {
 }
 func BenchmarkTraffic_GithubAll(b *testing.B) {
 	benchRoutes(b, githubTraffic, githubAPI)
+}
+func BenchmarkVanilla_GithubAll(b *testing.B) {
+	benchRoutes(b, githubVanilla, githubAPI)
 }
 func BenchmarkVulcan_GithubAll(b *testing.B) {
 	benchRoutes(b, githubVulcan, githubAPI)

--- a/gplus_test.go
+++ b/gplus_test.go
@@ -61,6 +61,7 @@ var (
 	gplusTango       http.Handler
 	gplusTigerTonic  http.Handler
 	gplusTraffic     http.Handler
+	gplusVanilla     http.Handler
 	gplusVulcan      http.Handler
 	// gplusZeus        http.Handler
 )
@@ -142,6 +143,9 @@ func init() {
 	})
 	calcMem("Traffic", func() {
 		gplusTraffic = loadTraffic(gplusAPI)
+	})
+	calcMem("Vanilla", func() {
+		gplusVanilla = loadVanilla(gplusAPI)
 	})
 	calcMem("Vulcan", func() {
 		gplusVulcan = loadVulcan(gplusAPI)
@@ -254,6 +258,10 @@ func BenchmarkTraffic_GPlusStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people", nil)
 	benchRequest(b, gplusTraffic, req)
 }
+func BenchmarkVanilla_GPlusStatic(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/people", nil)
+	benchRequest(b, gplusVanilla, req)
+}
 func BenchmarkVulcan_GPlusStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people", nil)
 	benchRequest(b, gplusVulcan, req)
@@ -364,6 +372,10 @@ func BenchmarkTigerTonic_GPlusParam(b *testing.B) {
 func BenchmarkTraffic_GPlusParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people/118051310819094153327", nil)
 	benchRequest(b, gplusTraffic, req)
+}
+func BenchmarkVanilla_GPlusParam(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/people/118051310819094153327", nil)
+	benchRequest(b, gplusVanilla, req)
 }
 func BenchmarkVulcan_GPlusParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people/118051310819094153327", nil)
@@ -476,6 +488,10 @@ func BenchmarkTraffic_GPlus2Params(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people/118051310819094153327/activities/123456789", nil)
 	benchRequest(b, gplusTraffic, req)
 }
+func BenchmarkVanilla_GPlus2Params(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/people/118051310819094153327/activities/123456789", nil)
+	benchRequest(b, gplusVanilla, req)
+}
 func BenchmarkVulcan_GPlus2Params(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people/118051310819094153327/activities/123456789", nil)
 	benchRequest(b, gplusVulcan, req)
@@ -561,6 +577,9 @@ func BenchmarkTigerTonic_GPlusAll(b *testing.B) {
 }
 func BenchmarkTraffic_GPlusAll(b *testing.B) {
 	benchRoutes(b, gplusTraffic, gplusAPI)
+}
+func BenchmarkVanilla_GPlusAll(b *testing.B) {
+	benchRoutes(b, gplusVanilla, gplusAPI)
 }
 func BenchmarkVulcan_GPlusAll(b *testing.B) {
 	benchRoutes(b, gplusVulcan, gplusAPI)

--- a/parse_test.go
+++ b/parse_test.go
@@ -81,6 +81,7 @@ var (
 	parseTango       http.Handler
 	parseTigerTonic  http.Handler
 	parseTraffic     http.Handler
+	parseVanilla     http.Handler
 	parseVulcan      http.Handler
 	// parseZeus        http.Handler
 )
@@ -162,6 +163,9 @@ func init() {
 	})
 	calcMem("Traffic", func() {
 		parseTraffic = loadTraffic(parseAPI)
+	})
+	calcMem("Vanilla", func() {
+		parseVanilla = loadVanilla(parseAPI)
 	})
 	calcMem("Vulcan", func() {
 		parseVulcan = loadVulcan(parseAPI)
@@ -274,6 +278,10 @@ func BenchmarkTraffic_ParseStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/users", nil)
 	benchRequest(b, parseTraffic, req)
 }
+func BenchmarkVanilla_ParseStatic(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/1/users", nil)
+	benchRequest(b, parseVanilla, req)
+}
 func BenchmarkVulcan_ParseStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/users", nil)
 	benchRequest(b, parseVulcan, req)
@@ -384,6 +392,10 @@ func BenchmarkTigerTonic_ParseParam(b *testing.B) {
 func BenchmarkTraffic_ParseParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/classes/go", nil)
 	benchRequest(b, parseTraffic, req)
+}
+func BenchmarkVanilla_ParseParam(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/1/classes/go", nil)
+	benchRequest(b, parseVanilla, req)
 }
 func BenchmarkVulcan_ParseParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/classes/go", nil)
@@ -496,6 +508,10 @@ func BenchmarkTraffic_Parse2Params(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/classes/go/123456789", nil)
 	benchRequest(b, parseTraffic, req)
 }
+func BenchmarkVanilla_Parse2Params(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/1/classes/go/123456789", nil)
+	benchRequest(b, parseVanilla, req)
+}
 func BenchmarkVulcan_Parse2Params(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/classes/go/123456789", nil)
 	benchRequest(b, parseVulcan, req)
@@ -581,6 +597,9 @@ func BenchmarkTigerTonic_ParseAll(b *testing.B) {
 }
 func BenchmarkTraffic_ParseAll(b *testing.B) {
 	benchRoutes(b, parseTraffic, parseAPI)
+}
+func BenchmarkVanilla_ParseAll(b *testing.B) {
+	benchRoutes(b, parseVanilla, parseAPI)
 }
 func BenchmarkVulcan_ParseAll(b *testing.B) {
 	benchRoutes(b, parseVulcan, parseAPI)

--- a/routers.go
+++ b/routers.go
@@ -17,6 +17,8 @@ import (
 	// - Keep the benchmark functions etc. alphabetically sorted
 	// - Make a pull request (without benchmark results) at
 	//   https://github.com/julienschmidt/go-http-routing-benchmark
+
+	"github.com/DATA-DOG/vanilla"
 	"github.com/Unknwon/macaron"
 	"github.com/ant0ine/go-json-rest/rest"
 	"github.com/astaxie/beego"
@@ -1279,6 +1281,34 @@ func loadTrafficSingle(method, path string, handler traffic.HttpHandleFunc) http
 		panic("Unknow HTTP method: " + method)
 	}
 	return router
+}
+
+// vanilla
+func vanillaHandlerWrite(w http.ResponseWriter, r *http.Request) {
+	io.WriteString(w, vanilla.Parameters(r).ByName("name"))
+}
+
+func vanillaHandlerTest(w http.ResponseWriter, r *http.Request) {
+	io.WriteString(w, r.RequestURI)
+}
+
+func loadVanilla(routes []route) http.Handler {
+	h := vanillaHandlerWrite
+	if loadTestHandler {
+		h = vanillaHandlerTest
+	}
+
+	m := vanilla.New()
+	for _, route := range routes {
+		m.Handle(route.method, route.path, http.HandlerFunc(h))
+	}
+	return m
+}
+
+func loadVanillaSingle(method, path string, handler http.HandlerFunc) http.Handler {
+	m := vanilla.New()
+	m.Handle(method, path, handler)
+	return m
 }
 
 // Mailgun Vulcan

--- a/routers_test.go
+++ b/routers_test.go
@@ -37,6 +37,7 @@ var (
 		{"Tango", loadTango},
 		{"TigerTonic", loadTigerTonic},
 		{"Traffic", loadTraffic},
+		{"Vanilla", loadVanilla},
 		{"Vulcan", loadVulcan},
 		// {"Zeus", loadZeus},
 	}

--- a/static_test.go
+++ b/static_test.go
@@ -197,6 +197,7 @@ var (
 	staticTango       http.Handler
 	staticTigerTonic  http.Handler
 	staticTraffic     http.Handler
+	staticVanilla     http.Handler
 	staticVulcan      http.Handler
 	// staticZeus        http.Handler
 )
@@ -287,6 +288,9 @@ func init() {
 	calcMem("Traffic", func() {
 		staticTraffic = loadTraffic(staticRoutes)
 	})
+	calcMem("Vanilla", func() {
+		staticVanilla = loadVanilla(staticRoutes)
+	})
 	calcMem("Vulcan", func() {
 		staticVulcan = loadVulcan(staticRoutes)
 	})
@@ -376,6 +380,9 @@ func BenchmarkTigerTonic_StaticAll(b *testing.B) {
 }
 func BenchmarkTraffic_StaticAll(b *testing.B) {
 	benchRoutes(b, staticTraffic, staticRoutes)
+}
+func BenchmarkVanilla_StaticAll(b *testing.B) {
+	benchRoutes(b, staticVanilla, staticRoutes)
 }
 func BenchmarkVulcan_StaticAll(b *testing.B) {
 	benchRoutes(b, staticVulcan, staticRoutes)


### PR DESCRIPTION
[Vanilla](https://github.com/DATA-DOG/vanilla) router aim is to serve **http.Handler**.
It combines the following packages:

- [httprouter](https://github.com/julienschmidt/httprouter)
- [alice](https://github.com/justinas/alice)
- [httpcontext](https://github.com/nbio/httpcontext)

It can be used as an example on how stable **GO** packages in the wild can be combined.
