### PR TITLE
Updated readme with note related to SIGQUIT from #44

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,13 @@ cd $GOPATH/src/github.com/julienschmidt/go-http-routing-benchmark
 go test -bench=.
 ```
 
+> **Note:** If you run the tests and it SIGQUIT's make the go test timeout longer (#44)
+>
+>```
+go test -timeout=2h -bench=.
+```
+
+
 You can bench specific frameworks only by using a regular expression as the value of the `bench` parameter:
 ```bash
 go test -bench="Martini|Gin|HttpMux"


### PR DESCRIPTION
Had to search the issues to see this. I assume as you add new benchmarks this will increasingly become an issue when running all benchmarks at once.