### PR TITLE
Add goji v2 benchmark

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -150,6 +150,12 @@ func BenchmarkGoji_Param(b *testing.B) {
 	r, _ := http.NewRequest("GET", "/user/gordon", nil)
 	benchRequest(b, router, r)
 }
+func BenchmarkGojiv2_Param(b *testing.B) {
+	router := loadGojiv2Single("GET", "/user/:name", gojiv2Handler)
+
+	r, _ := http.NewRequest("GET", "/user/gordon", nil)
+	benchRequest(b, router, r)
+}
 func BenchmarkGoJsonRest_Param(b *testing.B) {
 	router := loadGoJsonRestSingle("GET", "/user/:name", goJsonRestHandler)
 
@@ -321,6 +327,12 @@ func BenchmarkGocraftWeb_Param5(b *testing.B) {
 }
 func BenchmarkGoji_Param5(b *testing.B) {
 	router := loadGojiSingle("GET", fiveColon, httpHandlerFunc)
+
+	r, _ := http.NewRequest("GET", fiveRoute, nil)
+	benchRequest(b, router, r)
+}
+func BenchmarkGojiv2_Param5(b *testing.B) {
+	router := loadGojiv2Single("GET", fiveColon, gojiv2Handler)
 
 	r, _ := http.NewRequest("GET", fiveRoute, nil)
 	benchRequest(b, router, r)
@@ -499,6 +511,12 @@ func BenchmarkGoji_Param20(b *testing.B) {
 	r, _ := http.NewRequest("GET", twentyRoute, nil)
 	benchRequest(b, router, r)
 }
+func BenchmarkGojiv2_Param20(b *testing.B) {
+	router := loadGojiv2Single("GET", twentyColon, gojiv2Handler)
+
+	r, _ := http.NewRequest("GET", twentyRoute, nil)
+	benchRequest(b, router, r)
+}
 func BenchmarkGoJsonRest_Param20(b *testing.B) {
 	handler := loadGoJsonRestSingle("GET", twentyColon, goJsonRestHandler)
 
@@ -665,6 +683,12 @@ func BenchmarkGocraftWeb_ParamWrite(b *testing.B) {
 }
 func BenchmarkGoji_ParamWrite(b *testing.B) {
 	router := loadGojiSingle("GET", "/user/:name", gojiFuncWrite)
+
+	r, _ := http.NewRequest("GET", "/user/gordon", nil)
+	benchRequest(b, router, r)
+}
+func BenchmarkGojiv2_ParamWrite(b *testing.B) {
+	router := loadGojiv2Single("GET", "/user/:name", gojiv2HandlerWrite)
 
 	r, _ := http.NewRequest("GET", "/user/gordon", nil)
 	benchRequest(b, router, r)

--- a/github_test.go
+++ b/github_test.go
@@ -283,6 +283,7 @@ var (
 	githubGin         http.Handler
 	githubGocraftWeb  http.Handler
 	githubGoji        http.Handler
+	githubGojiv2      http.Handler
 	githubGoJsonRest  http.Handler
 	githubGoRestful   http.Handler
 	githubGorillaMux  http.Handler
@@ -332,6 +333,9 @@ func init() {
 	})
 	calcMem("Goji", func() {
 		githubGoji = loadGoji(githubAPI)
+	})
+	calcMem("Gojiv2", func() {
+		githubGojiv2 = loadGojiv2(githubAPI)
 	})
 	calcMem("GoJsonRest", func() {
 		githubGoJsonRest = loadGoJsonRest(githubAPI)
@@ -427,6 +431,10 @@ func BenchmarkGocraftWeb_GithubStatic(b *testing.B) {
 func BenchmarkGoji_GithubStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/user/repos", nil)
 	benchRequest(b, githubGoji, req)
+}
+func BenchmarkGojiv2_GithubStatic(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/user/repos", nil)
+	benchRequest(b, githubGojiv2, req)
 }
 func BenchmarkGoRestful_GithubStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/user/repos", nil)
@@ -539,6 +547,10 @@ func BenchmarkGoji_GithubParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/repos/julienschmidt/httprouter/stargazers", nil)
 	benchRequest(b, githubGoji, req)
 }
+func BenchmarkGojiv2_GithubParam(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/repos/julienschmidt/httprouter/stargazers", nil)
+	benchRequest(b, githubGojiv2, req)
+}
 func BenchmarkGoJsonRest_GithubParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/repos/julienschmidt/httprouter/stargazers", nil)
 	benchRequest(b, githubGoJsonRest, req)
@@ -640,6 +652,9 @@ func BenchmarkGocraftWeb_GithubAll(b *testing.B) {
 }
 func BenchmarkGoji_GithubAll(b *testing.B) {
 	benchRoutes(b, githubGoji, githubAPI)
+}
+func BenchmarkGojiv2_GithubAll(b *testing.B) {
+	benchRoutes(b, githubGojiv2, githubAPI)
 }
 func BenchmarkGoJsonRest_GithubAll(b *testing.B) {
 	benchRoutes(b, githubGoJsonRest, githubAPI)

--- a/gplus_test.go
+++ b/gplus_test.go
@@ -45,6 +45,7 @@ var (
 	gplusGin         http.Handler
 	gplusGocraftWeb  http.Handler
 	gplusGoji        http.Handler
+	gplusGojiv2      http.Handler
 	gplusGoJsonRest  http.Handler
 	gplusGoRestful   http.Handler
 	gplusGorillaMux  http.Handler
@@ -94,6 +95,9 @@ func init() {
 	})
 	calcMem("Goji", func() {
 		gplusGoji = loadGoji(gplusAPI)
+	})
+	calcMem("Gojiv2", func() {
+		gplusGojiv2 = loadGojiv2(gplusAPI)
 	})
 	calcMem("GoJsonRest", func() {
 		gplusGoJsonRest = loadGoJsonRest(gplusAPI)
@@ -189,6 +193,10 @@ func BenchmarkGocraftWeb_GPlusStatic(b *testing.B) {
 func BenchmarkGoji_GPlusStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people", nil)
 	benchRequest(b, gplusGoji, req)
+}
+func BenchmarkGojiv2_GPlusStatic(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/people", nil)
+	benchRequest(b, gplusGojiv2, req)
 }
 func BenchmarkGoJsonRest_GPlusStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people", nil)
@@ -301,6 +309,10 @@ func BenchmarkGoji_GPlusParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people/118051310819094153327", nil)
 	benchRequest(b, gplusGoji, req)
 }
+func BenchmarkGojiv2_GPlusParam(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/people/118051310819094153327", nil)
+	benchRequest(b, gplusGojiv2, req)
+}
 func BenchmarkGoJsonRest_GPlusParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people/118051310819094153327", nil)
 	benchRequest(b, gplusGoJsonRest, req)
@@ -412,6 +424,10 @@ func BenchmarkGoji_GPlus2Params(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people/118051310819094153327/activities/123456789", nil)
 	benchRequest(b, gplusGoji, req)
 }
+func BenchmarkGojiv2_GPlus2Params(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/people/118051310819094153327/activities/123456789", nil)
+	benchRequest(b, gplusGojiv2, req)
+}
 func BenchmarkGoJsonRest_GPlus2Params(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people/118051310819094153327/activities/123456789", nil)
 	benchRequest(b, gplusGoJsonRest, req)
@@ -513,6 +529,9 @@ func BenchmarkGocraftWeb_GPlusAll(b *testing.B) {
 }
 func BenchmarkGoji_GPlusAll(b *testing.B) {
 	benchRoutes(b, gplusGoji, gplusAPI)
+}
+func BenchmarkGojiv2_GPlusAll(b *testing.B) {
+	benchRoutes(b, gplusGojiv2, gplusAPI)
 }
 func BenchmarkGoJsonRest_GPlusAll(b *testing.B) {
 	benchRoutes(b, gplusGoJsonRest, gplusAPI)

--- a/parse_test.go
+++ b/parse_test.go
@@ -65,6 +65,7 @@ var (
 	parseGin         http.Handler
 	parseGocraftWeb  http.Handler
 	parseGoji        http.Handler
+	parseGojiv2      http.Handler
 	parseGoJsonRest  http.Handler
 	parseGoRestful   http.Handler
 	parseGorillaMux  http.Handler
@@ -114,6 +115,9 @@ func init() {
 	})
 	calcMem("Goji", func() {
 		parseGoji = loadGoji(parseAPI)
+	})
+	calcMem("Gojiv2", func() {
+		parseGojiv2 = loadGojiv2(parseAPI)
 	})
 	calcMem("GoJsonRest", func() {
 		parseGoJsonRest = loadGoJsonRest(parseAPI)
@@ -209,6 +213,10 @@ func BenchmarkGocraftWeb_ParseStatic(b *testing.B) {
 func BenchmarkGoji_ParseStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/users", nil)
 	benchRequest(b, parseGoji, req)
+}
+func BenchmarkGojiv2_ParseStatic(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/1/users", nil)
+	benchRequest(b, parseGojiv2, req)
 }
 func BenchmarkGoJsonRest_ParseStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/users", nil)
@@ -321,6 +329,10 @@ func BenchmarkGoji_ParseParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/classes/go", nil)
 	benchRequest(b, parseGoji, req)
 }
+func BenchmarkGojiv2_ParseParam(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/1/classes/go", nil)
+	benchRequest(b, parseGojiv2, req)
+}
 func BenchmarkGoJsonRest_ParseParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/classes/go", nil)
 	benchRequest(b, parseGoJsonRest, req)
@@ -432,6 +444,10 @@ func BenchmarkGoji_Parse2Params(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/classes/go/123456789", nil)
 	benchRequest(b, parseGoji, req)
 }
+func BenchmarkGojiv2_Parse2Params(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/1/classes/go/123456789", nil)
+	benchRequest(b, parseGojiv2, req)
+}
 func BenchmarkGoJsonRest_Parse2Params(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/classes/go/123456789", nil)
 	benchRequest(b, parseGoJsonRest, req)
@@ -533,6 +549,9 @@ func BenchmarkGocraftWeb_ParseAll(b *testing.B) {
 }
 func BenchmarkGoji_ParseAll(b *testing.B) {
 	benchRoutes(b, parseGoji, parseAPI)
+}
+func BenchmarkGojiv2_ParseAll(b *testing.B) {
+	benchRoutes(b, parseGojiv2, parseAPI)
 }
 func BenchmarkGoJsonRest_ParseAll(b *testing.B) {
 	benchRoutes(b, parseGoJsonRest, parseAPI)

--- a/routers.go
+++ b/routers.go
@@ -50,6 +50,9 @@ import (
 	"github.com/ursiform/bear"
 	"github.com/vanng822/r2router"
 	goji "github.com/zenazn/goji/web"
+	gojiv2 "goji.io"
+	gojiv2pat "goji.io/pat"
+	gcontext "golang.org/x/net/context"
 )
 
 type route struct {
@@ -521,6 +524,62 @@ func loadGojiSingle(method, path string, handler interface{}) http.Handler {
 		mux.Patch(path, handler)
 	case "DELETE":
 		mux.Delete(path, handler)
+	default:
+		panic("Unknow HTTP method: " + method)
+	}
+	return mux
+}
+
+// goji v2 (github.com/goji/goji)
+func gojiv2Handler(ctx gcontext.Context, w http.ResponseWriter, r *http.Request) {}
+
+func gojiv2HandlerWrite(ctx gcontext.Context, w http.ResponseWriter, r *http.Request) {
+	io.WriteString(w, gojiv2pat.Param(ctx, "name"))
+}
+
+func gojiv2HandlerTest(ctx gcontext.Context, w http.ResponseWriter, r *http.Request) {
+	io.WriteString(w, r.RequestURI)
+}
+
+func loadGojiv2(routes []route) http.Handler {
+	h := gojiv2Handler
+	if loadTestHandler {
+		h = gojiv2HandlerTest
+	}
+
+	mux := gojiv2.NewMux()
+	for _, route := range routes {
+		switch route.method {
+		case "GET":
+			mux.HandleFuncC(gojiv2pat.Get(route.path), h)
+		case "POST":
+			mux.HandleFuncC(gojiv2pat.Post(route.path), h)
+		case "PUT":
+			mux.HandleFuncC(gojiv2pat.Put(route.path), h)
+		case "PATCH":
+			mux.HandleFuncC(gojiv2pat.Patch(route.path), h)
+		case "DELETE":
+			mux.HandleFuncC(gojiv2pat.Delete(route.path), h)
+		default:
+			panic("Unknown HTTP method: " + route.method)
+		}
+	}
+	return mux
+}
+
+func loadGojiv2Single(method, path string, handler gojiv2.HandlerFunc) http.Handler {
+	mux := gojiv2.NewMux()
+	switch method {
+	case "GET":
+		mux.HandleFuncC(gojiv2pat.Get(path), handler)
+	case "POST":
+		mux.HandleFuncC(gojiv2pat.Post(path), handler)
+	case "PUT":
+		mux.HandleFuncC(gojiv2pat.Put(path), handler)
+	case "PATCH":
+		mux.HandleFuncC(gojiv2pat.Patch(path), handler)
+	case "DELETE":
+		mux.HandleFuncC(gojiv2pat.Delete(path), handler)
 	default:
 		panic("Unknow HTTP method: " + method)
 	}

--- a/routers_test.go
+++ b/routers_test.go
@@ -21,6 +21,7 @@ var (
 		{"Gin", loadGin},
 		{"GocraftWeb", loadGocraftWeb},
 		{"Goji", loadGoji},
+		{"Gojiv2", loadGojiv2},
 		{"GoJsonRest", loadGoJsonRest},
 		{"GoRestful", loadGoRestful},
 		{"GorillaMux", loadGorillaMux},

--- a/static_test.go
+++ b/static_test.go
@@ -181,6 +181,7 @@ var (
 	staticGin         http.Handler
 	staticGocraftWeb  http.Handler
 	staticGoji        http.Handler
+	staticGojiv2      http.Handler
 	staticGoJsonRest  http.Handler
 	staticGoRestful   http.Handler
 	staticGorillaMux  http.Handler
@@ -238,6 +239,9 @@ func init() {
 	})
 	calcMem("Goji", func() {
 		staticGoji = loadGoji(staticRoutes)
+	})
+	calcMem("Gojiv2", func() {
+		staticGojiv2 = loadGojiv2(staticRoutes)
 	})
 	calcMem("GoJsonRest", func() {
 		staticGoJsonRest = loadGoJsonRest(staticRoutes)
@@ -328,6 +332,9 @@ func BenchmarkGocraftWeb_StaticAll(b *testing.B) {
 }
 func BenchmarkGoji_StaticAll(b *testing.B) {
 	benchRoutes(b, staticGoji, staticRoutes)
+}
+func BenchmarkGojiv2_StaticAll(b *testing.B) {
+	benchRoutes(b, staticGojiv2, staticRoutes)
 }
 func BenchmarkGoJsonRest_StaticAll(b *testing.B) {
 	benchRoutes(b, staticGoJsonRest, staticRoutes)


### PR DESCRIPTION
Adding benchmarks for goji.io, the successor to github.com/zenazn/goji.

Unfortunately everything is named Gojiv2 so you can no longer run only the Goji benchmark. Open to suggestions for better naming, or could go back and name Goji to Gojiv1 or similar.


