### PR TITLE
Get the benchmark compiling / running again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 sudo: false
 language: go
+before_install:
+  - 'mkdir -p $GOPATH/bin'
+  - 'curl https://glide.sh/get | /bin/bash'
+install:
+  - 'glide install'
+script:
+  - 'go test -v $(glide novendor)'
 go:
-  - 1.4
+  - 1.7.1
   - tip

--- a/bench_test.go
+++ b/bench_test.go
@@ -242,12 +242,13 @@ func BenchmarkRevel_Param(b *testing.B) {
 	r, _ := http.NewRequest("GET", "/user/gordon", nil)
 	benchRequest(b, router, r)
 }
-func BenchmarkRivet_Param(b *testing.B) {
-	router := loadRivetSingle("GET", "/user/:name", rivetHandler)
 
-	r, _ := http.NewRequest("GET", "/user/gordon", nil)
-	benchRequest(b, router, r)
-}
+// func BenchmarkRivet_Param(b *testing.B) {
+// 	router := loadRivetSingle("GET", "/user/:name", rivetHandler)
+
+// 	r, _ := http.NewRequest("GET", "/user/gordon", nil)
+// 	benchRequest(b, router, r)
+// }
 func BenchmarkTango_Param(b *testing.B) {
 	router := loadTangoSingle("GET", "/user/:name", tangoHandler)
 
@@ -429,12 +430,13 @@ func BenchmarkRevel_Param5(b *testing.B) {
 	r, _ := http.NewRequest("GET", fiveRoute, nil)
 	benchRequest(b, router, r)
 }
-func BenchmarkRivet_Param5(b *testing.B) {
-	router := loadRivetSingle("GET", fiveColon, rivetHandler)
 
-	r, _ := http.NewRequest("GET", fiveRoute, nil)
-	benchRequest(b, router, r)
-}
+// func BenchmarkRivet_Param5(b *testing.B) {
+// 	router := loadRivetSingle("GET", fiveColon, rivetHandler)
+
+// 	r, _ := http.NewRequest("GET", fiveRoute, nil)
+// 	benchRequest(b, router, r)
+// }
 func BenchmarkTango_Param5(b *testing.B) {
 	router := loadTangoSingle("GET", fiveColon, tangoHandler)
 
@@ -616,12 +618,13 @@ func BenchmarkRevel_Param20(b *testing.B) {
 	r, _ := http.NewRequest("GET", twentyRoute, nil)
 	benchRequest(b, router, r)
 }
-func BenchmarkRivet_Param20(b *testing.B) {
-	router := loadRivetSingle("GET", twentyColon, rivetHandler)
 
-	r, _ := http.NewRequest("GET", twentyRoute, nil)
-	benchRequest(b, router, r)
-}
+// func BenchmarkRivet_Param20(b *testing.B) {
+// 	router := loadRivetSingle("GET", twentyColon, rivetHandler)
+
+// 	r, _ := http.NewRequest("GET", twentyRoute, nil)
+// 	benchRequest(b, router, r)
+// }
 func BenchmarkTango_Param20(b *testing.B) {
 	router := loadTangoSingle("GET", twentyColon, tangoHandler)
 
@@ -799,12 +802,13 @@ func BenchmarkRevel_ParamWrite(b *testing.B) {
 	r, _ := http.NewRequest("GET", "/user/gordon", nil)
 	benchRequest(b, router, r)
 }
-func BenchmarkRivet_ParamWrite(b *testing.B) {
-	router := loadRivetSingle("GET", "/user/:name", rivetHandlerWrite)
 
-	r, _ := http.NewRequest("GET", "/user/gordon", nil)
-	benchRequest(b, router, r)
-}
+// func BenchmarkRivet_ParamWrite(b *testing.B) {
+// 	router := loadRivetSingle("GET", "/user/:name", rivetHandlerWrite)
+
+// 	r, _ := http.NewRequest("GET", "/user/gordon", nil)
+// 	benchRequest(b, router, r)
+// }
 func BenchmarkTango_ParamWrite(b *testing.B) {
 	router := loadTangoSingle("GET", "/user/:name", tangoHandlerWrite)
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -126,12 +126,14 @@ func BenchmarkDenco_Param(b *testing.B) {
 	r, _ := http.NewRequest("GET", "/user/gordon", nil)
 	benchRequest(b, router, r)
 }
-func BenchmarkEcho_Param(b *testing.B) {
-	router := loadEchoSingle("GET", "/user/:name", echoHandler)
 
-	r, _ := http.NewRequest("GET", "/user/gordon", nil)
-	benchRequest(b, router, r)
-}
+// func BenchmarkEcho_Param(b *testing.B) {
+// 	router := loadEchoSingle("GET", "/user/:name", echoHandler)
+
+// 	r, _ := http.NewRequest("GET", "/user/gordon", nil)
+// 	benchRequest(b, router, r)
+// }
+
 func BenchmarkGin_Param(b *testing.B) {
 	router := loadGinSingle("GET", "/user/:name", ginHandle)
 
@@ -313,12 +315,13 @@ func BenchmarkDenco_Param5(b *testing.B) {
 	r, _ := http.NewRequest("GET", fiveRoute, nil)
 	benchRequest(b, router, r)
 }
-func BenchmarkEcho_Param5(b *testing.B) {
-	router := loadEchoSingle("GET", fiveColon, echoHandler)
 
-	r, _ := http.NewRequest("GET", fiveRoute, nil)
-	benchRequest(b, router, r)
-}
+// func BenchmarkEcho_Param5(b *testing.B) {
+// 	router := loadEchoSingle("GET", fiveColon, echoHandler)
+
+// 	r, _ := http.NewRequest("GET", fiveRoute, nil)
+// 	benchRequest(b, router, r)
+// }
 func BenchmarkGin_Param5(b *testing.B) {
 	router := loadGinSingle("GET", fiveColon, ginHandle)
 
@@ -499,12 +502,13 @@ func BenchmarkDenco_Param20(b *testing.B) {
 	r, _ := http.NewRequest("GET", twentyRoute, nil)
 	benchRequest(b, router, r)
 }
-func BenchmarkEcho_Param20(b *testing.B) {
-	router := loadEchoSingle("GET", twentyColon, echoHandler)
 
-	r, _ := http.NewRequest("GET", twentyRoute, nil)
-	benchRequest(b, router, r)
-}
+// func BenchmarkEcho_Param20(b *testing.B) {
+// 	router := loadEchoSingle("GET", twentyColon, echoHandler)
+
+// 	r, _ := http.NewRequest("GET", twentyRoute, nil)
+// 	benchRequest(b, router, r)
+// }
 func BenchmarkGin_Param20(b *testing.B) {
 	router := loadGinSingle("GET", twentyColon, ginHandle)
 
@@ -681,12 +685,13 @@ func BenchmarkDenco_ParamWrite(b *testing.B) {
 	r, _ := http.NewRequest("GET", "/user/gordon", nil)
 	benchRequest(b, router, r)
 }
-func BenchmarkEcho_ParamWrite(b *testing.B) {
-	router := loadEchoSingle("GET", "/user/:name", echoHandlerWrite)
 
-	r, _ := http.NewRequest("GET", "/user/gordon", nil)
-	benchRequest(b, router, r)
-}
+// func BenchmarkEcho_ParamWrite(b *testing.B) {
+// 	router := loadEchoSingle("GET", "/user/:name", echoHandlerWrite)
+
+// 	r, _ := http.NewRequest("GET", "/user/gordon", nil)
+// 	benchRequest(b, router, r)
+// }
 func BenchmarkGin_ParamWrite(b *testing.B) {
 	router := loadGinSingle("GET", "/user/:name", ginHandleWrite)
 

--- a/github_test.go
+++ b/github_test.go
@@ -296,12 +296,12 @@ var (
 	githubPossum      http.Handler
 	githubR2router    http.Handler
 	githubRevel       http.Handler
-	githubRivet       http.Handler
 	githubTango       http.Handler
 	githubTigerTonic  http.Handler
 	githubTraffic     http.Handler
 	githubVulcan      http.Handler
 	// githubEcho        http.Handler
+	// githubRivet       http.Handler
 	// githubZeus        http.Handler
 )
 
@@ -377,9 +377,9 @@ func init() {
 	calcMem("Revel", func() {
 		githubRevel = loadRevel(githubAPI)
 	})
-	calcMem("Rivet", func() {
-		githubRivet = loadRivet(githubAPI)
-	})
+	// calcMem("Rivet", func() {
+	// 	githubRivet = loadRivet(githubAPI)
+	// })
 	calcMem("Tango", func() {
 		githubTango = loadTango(githubAPI)
 	})
@@ -493,10 +493,11 @@ func BenchmarkRevel_GithubStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/user/repos", nil)
 	benchRequest(b, githubRevel, req)
 }
-func BenchmarkRivet_GithubStatic(b *testing.B) {
-	req, _ := http.NewRequest("GET", "/user/repos", nil)
-	benchRequest(b, githubRivet, req)
-}
+
+// func BenchmarkRivet_GithubStatic(b *testing.B) {
+// 	req, _ := http.NewRequest("GET", "/user/repos", nil)
+// 	benchRequest(b, githubRivet, req)
+// }
 func BenchmarkTango_GithubStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/user/repos", nil)
 	benchRequest(b, githubTango, req)
@@ -613,10 +614,11 @@ func BenchmarkRevel_GithubParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/repos/julienschmidt/httprouter/stargazers", nil)
 	benchRequest(b, githubRevel, req)
 }
-func BenchmarkRivet_GithubParam(b *testing.B) {
-	req, _ := http.NewRequest("GET", "/repos/julienschmidt/httprouter/stargazers", nil)
-	benchRequest(b, githubRivet, req)
-}
+
+// func BenchmarkRivet_GithubParam(b *testing.B) {
+// 	req, _ := http.NewRequest("GET", "/repos/julienschmidt/httprouter/stargazers", nil)
+// 	benchRequest(b, githubRivet, req)
+// }
 func BenchmarkTango_GithubParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/repos/julienschmidt/httprouter/stargazers", nil)
 	benchRequest(b, githubTango, req)
@@ -710,9 +712,10 @@ func BenchmarkR2router_GithubAll(b *testing.B) {
 func BenchmarkRevel_GithubAll(b *testing.B) {
 	benchRoutes(b, githubRevel, githubAPI)
 }
-func BenchmarkRivet_GithubAll(b *testing.B) {
-	benchRoutes(b, githubRivet, githubAPI)
-}
+
+// func BenchmarkRivet_GithubAll(b *testing.B) {
+// 	benchRoutes(b, githubRivet, githubAPI)
+// }
 func BenchmarkTango_GithubAll(b *testing.B) {
 	benchRoutes(b, githubTango, githubAPI)
 }

--- a/github_test.go
+++ b/github_test.go
@@ -279,7 +279,6 @@ var (
 	githubBeego       http.Handler
 	githubBone        http.Handler
 	githubDenco       http.Handler
-	githubEcho        http.Handler
 	githubGin         http.Handler
 	githubGocraftWeb  http.Handler
 	githubGoji        http.Handler
@@ -302,6 +301,7 @@ var (
 	githubTigerTonic  http.Handler
 	githubTraffic     http.Handler
 	githubVulcan      http.Handler
+	// githubEcho        http.Handler
 	// githubZeus        http.Handler
 )
 
@@ -323,9 +323,9 @@ func init() {
 	calcMem("Denco", func() {
 		githubDenco = loadDenco(githubAPI)
 	})
-	calcMem("Echo", func() {
-		githubEcho = loadEcho(githubAPI)
-	})
+	// calcMem("Echo", func() {
+	// 	githubEcho = loadEcho(githubAPI)
+	// })
 	calcMem("Gin", func() {
 		githubGin = loadGin(githubAPI)
 	})
@@ -420,10 +420,11 @@ func BenchmarkDenco_GithubStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/user/repos", nil)
 	benchRequest(b, githubDenco, req)
 }
-func BenchmarkEcho_GithubStatic(b *testing.B) {
-	req, _ := http.NewRequest("GET", "/user/repos", nil)
-	benchRequest(b, githubEcho, req)
-}
+
+// func BenchmarkEcho_GithubStatic(b *testing.B) {
+// 	req, _ := http.NewRequest("GET", "/user/repos", nil)
+// 	benchRequest(b, githubEcho, req)
+// }
 func BenchmarkGin_GithubStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/user/repos", nil)
 	benchRequest(b, githubGin, req)
@@ -539,10 +540,11 @@ func BenchmarkDenco_GithubParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/repos/julienschmidt/httprouter/stargazers", nil)
 	benchRequest(b, githubDenco, req)
 }
-func BenchmarkEcho_GithubParam(b *testing.B) {
-	req, _ := http.NewRequest("GET", "/repos/julienschmidt/httprouter/stargazers", nil)
-	benchRequest(b, githubEcho, req)
-}
+
+// func BenchmarkEcho_GithubParam(b *testing.B) {
+// 	req, _ := http.NewRequest("GET", "/repos/julienschmidt/httprouter/stargazers", nil)
+// 	benchRequest(b, githubEcho, req)
+// }
 func BenchmarkGin_GithubParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/repos/julienschmidt/httprouter/stargazers", nil)
 	benchRequest(b, githubGin, req)
@@ -653,9 +655,10 @@ func BenchmarkBone_GithubAll(b *testing.B) {
 func BenchmarkDenco_GithubAll(b *testing.B) {
 	benchRoutes(b, githubDenco, githubAPI)
 }
-func BenchmarkEcho_GithubAll(b *testing.B) {
-	benchRoutes(b, githubEcho, githubAPI)
-}
+
+// func BenchmarkEcho_GithubAll(b *testing.B) {
+// 	benchRoutes(b, githubEcho, githubAPI)
+// }
 func BenchmarkGin_GithubAll(b *testing.B) {
 	benchRoutes(b, githubGin, githubAPI)
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,165 @@
+hash: 58ae86606e17b8ba617eeda130177a3b153ed08dd3c8749df52445c886501cd8
+updated: 2016-09-25T05:55:37.309795783-07:00
+imports:
+- name: github.com/agtorre/gocolorize
+  version: f42b554bf7f006936130c9bb4f971afd2d87f671
+- name: github.com/ant0ine/go-json-rest
+  version: 4f1814e6e38174c46a6cccdda906987d04b735f6
+  subpackages:
+  - rest
+  - rest/trie
+- name: github.com/astaxie/beego
+  version: 2d87d4feafeea0a133d217a82e6e02df0348fed5
+  subpackages:
+  - config
+  - context
+  - grace
+  - logs
+  - session
+  - toolbox
+  - utils
+- name: github.com/bmizerany/pat
+  version: c068ca2f0aacee5ac3681d68e4d0a003b7d1fd2c
+- name: github.com/codegangsta/inject
+  version: 33e0aa1cb7c019ccc3fbe049a8262a6403d30504
+- name: github.com/dimfeld/httppath
+  version: c8e499c3ef3c3e272ed8bdcc1ccf39f73c88debc
+- name: github.com/dimfeld/httptreemux
+  version: 96acf0909c0b45ebf4a25a816cedc6d317e63679
+- name: github.com/emicklei/go-restful
+  version: 3d66f886316ac990eb502aaa89ea38546420b8b7
+  subpackages:
+  - log
+- name: github.com/gin-gonic/gin
+  version: f931d1ea80ae95a6fc739213cdd9399bd2967fb6
+  subpackages:
+  - binding
+  - render
+- name: github.com/go-martini/martini
+  version: fe605b5cd210047ae3bb73d2b69a5b912a9b423d
+- name: github.com/go-playground/form
+  version: d18f24949d2fcf4b367cff1424a9e1a60dd5507f
+- name: github.com/go-playground/lars
+  version: afe609a03836b0ee3e82610609c8e6e50443b725
+- name: github.com/go-zoo/bone
+  version: ab498accda34adf6103219275fd01a50b0ffe68c
+- name: github.com/gocraft/web
+  version: c8ca29bc8a1cec97abe95c662e29dd8d31aff6e3
+- name: github.com/golang/protobuf
+  version: 2402d76f3d41f928c7902a765dfc872356dd3aad
+  subpackages:
+  - proto
+- name: github.com/gorilla/context
+  version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
+- name: github.com/gorilla/mux
+  version: 757bef944d0f21880861c2dd9c871ca543023cba
+- name: github.com/gorilla/websocket
+  version: 2d1e4548da234d9cb742cc3628556fef86aafbac
+- name: github.com/julienschmidt/httprouter
+  version: d8ff598a019f2c7bad0980917a588193cf26666e
+- name: github.com/klauspost/compress
+  version: d0763f13d86e630f5d3ea9fa848a6ecc68255297
+  subpackages:
+  - flate
+  - gzip
+  - zlib
+- name: github.com/klauspost/cpuid
+  version: 09cded8978dc9e80714c4d85b0322337b0a1e5e0
+- name: github.com/klauspost/crc32
+  version: 19b0b332c9e4516a6370a0456e6182c3b5036720
+- name: github.com/labstack/echo
+  version: 54a4d3140722793aa1cc430bd8a4a73aedff2783
+- name: github.com/lunny/log
+  version: 7887c61bf0de75586961948b286be6f7d05d9f58
+- name: github.com/lunny/tango
+  version: 2c5931858d843e7a54cb8cf56a567a66bee28882
+- name: github.com/mailgun/route
+  version: 61904570391bdf22252f8e376b49a57593d9124c
+- name: github.com/manucorporat/sse
+  version: ee05b128a739a0fb76c7ebd3ae4810c1de808d6d
+- name: github.com/mikespook/possum
+  version: 159dc6eacda42af0ce776cab22cb37e6e6e75aec
+  subpackages:
+  - router
+  - session
+  - view
+- name: github.com/naoina/denco
+  version: 9af2ba0e24214bac003821f4a501b131b2e04c75
+- name: github.com/naoina/kocha-urlrouter
+  version: ad3a6f079210b998b69308c37d7a9b10ba4a477d
+  subpackages:
+  - doublearray
+- name: github.com/oxtoacart/bpool
+  version: 4e1c5567d7c2dd59fa4c7c83d34c2f3528b025d6
+- name: github.com/philhofer/fwd
+  version: 98c11a7a6ec829d672b03833c3d69a7fae1ca972
+- name: github.com/pilu/config
+  version: 3eb99e6c0b9a2dae0f56f05552c06ca5a643919b
+- name: github.com/pilu/traffic
+  version: bccecb6def5c1d1eea8514b3e1cb7f2371571d8e
+- name: github.com/plimble/ace
+  version: 8ece619a879d9795f046003428a0940dc8152829
+- name: github.com/plimble/sessions
+  version: 9b87d5a817e27cd53d02ea97c30603626a9c579b
+- name: github.com/plimble/utils
+  version: fe08d46675cd09e170c0fb6b7b4e4587e14d0451
+  subpackages:
+  - pool
+- name: github.com/rcrowley/go-metrics
+  version: ab2277b1c5d15c3cba104e9cbddbdfc622df5ad8
+- name: github.com/rcrowley/go-tigertonic
+  version: 1199db5ea2f29309e20f6c70009b21e7e8810d6e
+- name: github.com/revel/config
+  version: 75f5ee659b5338d1ce823536fe9b9e50b4de01b4
+- name: github.com/revel/revel
+  version: 8d01a054f6bca9430b3e497fe7b4f20ec8f054ce
+- name: github.com/robfig/pathtree
+  version: 41257a1839e945fce74afd070e02bab2ea2c776a
+- name: github.com/satori/go.uuid
+  version: 0aa62d5ddceb50dbcb909d790b5345affd3669b6
+- name: github.com/tinylib/msgp
+  version: ad0ff2e232ad2e37faf67087fb24bf8d04a8ce20
+  subpackages:
+  - msgp
+- name: github.com/typepress/rivet
+  version: d62b4fcaf6b9766638d1eb0c41d8a3af7813fc48
+- name: github.com/Unknwon/com
+  version: 28b053d5a2923b87ce8c5a08f3af779894a72758
+- name: github.com/Unknwon/macaron
+  version: 9b82b0372a4edf52f66fbc8feaa6aafe0123001d
+  subpackages:
+  - inject
+- name: github.com/ursiform/bear
+  version: 00ea7058124d03e239c5446a6cce4f9cf6f5bb0e
+- name: github.com/vanng822/r2router
+  version: 1023140a4f309480a35668e695deda550100f502
+- name: github.com/vulcand/predicate
+  version: 19b9dde14240d94c804ae5736ad0e1de10bf8fe6
+- name: github.com/zenazn/goji
+  version: 4d7077956293261309684d3cf1af673f773c6819
+  subpackages:
+  - web
+- name: goji.io
+  version: bc2e9e7dc2769805d1b6ce4dc48ec23a03ae82ec
+  subpackages:
+  - internal
+  - pat
+  - pattern
+- name: golang.org/x/net
+  version: f315505cf3349909cdf013ea56690da34e96a451
+  subpackages:
+  - context
+  - websocket
+- name: golang.org/x/sys
+  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
+  subpackages:
+  - unix
+- name: gopkg.in/fsnotify.v1
+  version: a8a77c9133d2d6fd8334f3260d06f60e8d80a5fb
+- name: gopkg.in/go-playground/validator.v8
+  version: c193cecd124b5cc722d7ee5538e945bdb3348435
+- name: gopkg.in/ini.v1
+  version: 6e4869b434bd001f6983749881c7ead3545887d8
+- name: gopkg.in/yaml.v2
+  version: 31c299268d302dd0aa9a0dcf765a3d58971ac83f
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,48 @@
+package: github.com/julienschmidt/go-http-routing-benchmark
+import:
+- package: github.com/Unknwon/macaron
+- package: github.com/ant0ine/go-json-rest
+  subpackages:
+  - rest
+- package: github.com/astaxie/beego
+  subpackages:
+  - context
+- package: github.com/bmizerany/pat
+- package: github.com/dimfeld/httptreemux
+- package: github.com/emicklei/go-restful
+- package: github.com/gin-gonic/gin
+- package: github.com/go-martini/martini
+- package: github.com/go-playground/lars
+- package: github.com/go-zoo/bone
+- package: github.com/gocraft/web
+- package: github.com/gorilla/mux
+- package: github.com/julienschmidt/httprouter
+- package: github.com/labstack/echo
+- package: github.com/lunny/log
+- package: github.com/lunny/tango
+- package: github.com/mailgun/route
+- package: github.com/mikespook/possum
+  subpackages:
+  - router
+  - view
+- package: github.com/naoina/denco
+- package: github.com/naoina/kocha-urlrouter
+  subpackages:
+  - doublearray
+- package: github.com/pilu/traffic
+- package: github.com/plimble/ace
+- package: github.com/rcrowley/go-tigertonic
+- package: github.com/revel/revel
+- package: github.com/robfig/pathtree
+- package: github.com/typepress/rivet
+- package: github.com/ursiform/bear
+- package: github.com/vanng822/r2router
+- package: github.com/zenazn/goji
+  subpackages:
+  - web
+- package: goji.io
+  subpackages:
+  - pat
+- package: golang.org/x/net
+  subpackages:
+  - context

--- a/gplus_test.go
+++ b/gplus_test.go
@@ -41,7 +41,6 @@ var (
 	gplusBeego       http.Handler
 	gplusBone        http.Handler
 	gplusDenco       http.Handler
-	gplusEcho        http.Handler
 	gplusGin         http.Handler
 	gplusGocraftWeb  http.Handler
 	gplusGoji        http.Handler
@@ -64,6 +63,7 @@ var (
 	gplusTigerTonic  http.Handler
 	gplusTraffic     http.Handler
 	gplusVulcan      http.Handler
+	// gplusEcho        http.Handler
 	// gplusZeus        http.Handler
 )
 
@@ -85,9 +85,9 @@ func init() {
 	calcMem("Denco", func() {
 		gplusDenco = loadDenco(gplusAPI)
 	})
-	calcMem("Echo", func() {
-		gplusEcho = loadEcho(gplusAPI)
-	})
+	// calcMem("Echo", func() {
+	// 	gplusEcho = loadEcho(gplusAPI)
+	// })
 	calcMem("Gin", func() {
 		gplusGin = loadGin(gplusAPI)
 	})
@@ -182,10 +182,11 @@ func BenchmarkDenco_GPlusStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people", nil)
 	benchRequest(b, gplusDenco, req)
 }
-func BenchmarkEcho_GPlusStatic(b *testing.B) {
-	req, _ := http.NewRequest("GET", "/people", nil)
-	benchRequest(b, gplusEcho, req)
-}
+
+// func BenchmarkEcho_GPlusStatic(b *testing.B) {
+// 	req, _ := http.NewRequest("GET", "/people", nil)
+// 	benchRequest(b, gplusEcho, req)
+// }
 func BenchmarkGin_GPlusStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people", nil)
 	benchRequest(b, gplusGin, req)
@@ -301,10 +302,11 @@ func BenchmarkDenco_GPlusParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people/118051310819094153327", nil)
 	benchRequest(b, gplusDenco, req)
 }
-func BenchmarkEcho_GPlusParam(b *testing.B) {
-	req, _ := http.NewRequest("GET", "/people/118051310819094153327", nil)
-	benchRequest(b, gplusEcho, req)
-}
+
+// func BenchmarkEcho_GPlusParam(b *testing.B) {
+// 	req, _ := http.NewRequest("GET", "/people/118051310819094153327", nil)
+// 	benchRequest(b, gplusEcho, req)
+// }
 func BenchmarkGin_GPlusParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people/118051310819094153327", nil)
 	benchRequest(b, gplusGin, req)
@@ -420,10 +422,11 @@ func BenchmarkDenco_GPlus2Params(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people/118051310819094153327/activities/123456789", nil)
 	benchRequest(b, gplusDenco, req)
 }
-func BenchmarkEcho_GPlus2Params(b *testing.B) {
-	req, _ := http.NewRequest("GET", "/people/118051310819094153327/activities/123456789", nil)
-	benchRequest(b, gplusEcho, req)
-}
+
+// func BenchmarkEcho_GPlus2Params(b *testing.B) {
+// 	req, _ := http.NewRequest("GET", "/people/118051310819094153327/activities/123456789", nil)
+// 	benchRequest(b, gplusEcho, req)
+// }
 func BenchmarkGin_GPlus2Params(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people/118051310819094153327/activities/123456789", nil)
 	benchRequest(b, gplusGin, req)
@@ -534,9 +537,10 @@ func BenchmarkBone_GPlusAll(b *testing.B) {
 func BenchmarkDenco_GPlusAll(b *testing.B) {
 	benchRoutes(b, gplusDenco, gplusAPI)
 }
-func BenchmarkEcho_GPlusAll(b *testing.B) {
-	benchRoutes(b, gplusEcho, gplusAPI)
-}
+
+// func BenchmarkEcho_GPlusAll(b *testing.B) {
+// 	benchRoutes(b, gplusEcho, gplusAPI)
+// }
 func BenchmarkGin_GPlusAll(b *testing.B) {
 	benchRoutes(b, gplusGin, gplusAPI)
 }

--- a/gplus_test.go
+++ b/gplus_test.go
@@ -58,12 +58,12 @@ var (
 	gplusPossum      http.Handler
 	gplusR2router    http.Handler
 	gplusRevel       http.Handler
-	gplusRivet       http.Handler
 	gplusTango       http.Handler
 	gplusTigerTonic  http.Handler
 	gplusTraffic     http.Handler
 	gplusVulcan      http.Handler
 	// gplusEcho        http.Handler
+	// gplusRivet       http.Handler
 	// gplusZeus        http.Handler
 )
 
@@ -139,9 +139,9 @@ func init() {
 	calcMem("Revel", func() {
 		gplusRevel = loadRevel(gplusAPI)
 	})
-	calcMem("Rivet", func() {
-		gplusRivet = loadRivet(gplusAPI)
-	})
+	// calcMem("Rivet", func() {
+	// 	gplusRivet = loadRivet(gplusAPI)
+	// })
 	calcMem("Tango", func() {
 		gplusTango = loadTango(gplusAPI)
 	})
@@ -255,10 +255,11 @@ func BenchmarkRevel_GPlusStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people", nil)
 	benchRequest(b, gplusRevel, req)
 }
-func BenchmarkRivet_GPlusStatic(b *testing.B) {
-	req, _ := http.NewRequest("GET", "/people", nil)
-	benchRequest(b, gplusRivet, req)
-}
+
+// func BenchmarkRivet_GPlusStatic(b *testing.B) {
+// 	req, _ := http.NewRequest("GET", "/people", nil)
+// 	benchRequest(b, gplusRivet, req)
+// }
 func BenchmarkTango_GPlusStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people", nil)
 	benchRequest(b, gplusTango, req)
@@ -375,10 +376,11 @@ func BenchmarkRevel_GPlusParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people/118051310819094153327", nil)
 	benchRequest(b, gplusRevel, req)
 }
-func BenchmarkRivet_GPlusParam(b *testing.B) {
-	req, _ := http.NewRequest("GET", "/people/118051310819094153327", nil)
-	benchRequest(b, gplusRivet, req)
-}
+
+// func BenchmarkRivet_GPlusParam(b *testing.B) {
+// 	req, _ := http.NewRequest("GET", "/people/118051310819094153327", nil)
+// 	benchRequest(b, gplusRivet, req)
+// }
 func BenchmarkTango_GPlusParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people/118051310819094153327", nil)
 	benchRequest(b, gplusTango, req)
@@ -495,10 +497,11 @@ func BenchmarkRevel_GPlus2Params(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people/118051310819094153327/activities/123456789", nil)
 	benchRequest(b, gplusRevel, req)
 }
-func BenchmarkRivet_GPlus2Params(b *testing.B) {
-	req, _ := http.NewRequest("GET", "/people/118051310819094153327/activities/123456789", nil)
-	benchRequest(b, gplusRivet, req)
-}
+
+// func BenchmarkRivet_GPlus2Params(b *testing.B) {
+// 	req, _ := http.NewRequest("GET", "/people/118051310819094153327/activities/123456789", nil)
+// 	benchRequest(b, gplusRivet, req)
+// }
 func BenchmarkTango_GPlus2Params(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/people/118051310819094153327/activities/123456789", nil)
 	benchRequest(b, gplusTango, req)
@@ -592,9 +595,10 @@ func BenchmarkR2router_GPlusAll(b *testing.B) {
 func BenchmarkRevel_GPlusAll(b *testing.B) {
 	benchRoutes(b, gplusRevel, gplusAPI)
 }
-func BenchmarkRivet_GPlusAll(b *testing.B) {
-	benchRoutes(b, gplusRivet, gplusAPI)
-}
+
+// func BenchmarkRivet_GPlusAll(b *testing.B) {
+// 	benchRoutes(b, gplusRivet, gplusAPI)
+// }
 func BenchmarkTango_GPlusAll(b *testing.B) {
 	benchRoutes(b, gplusTango, gplusAPI)
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -78,12 +78,12 @@ var (
 	parsePossum      http.Handler
 	parseR2router    http.Handler
 	parseRevel       http.Handler
-	parseRivet       http.Handler
 	parseTango       http.Handler
 	parseTigerTonic  http.Handler
 	parseTraffic     http.Handler
 	parseVulcan      http.Handler
 	// parseEcho        http.Handler
+	// parseRivet       http.Handler
 	// parseZeus        http.Handler
 )
 
@@ -159,9 +159,9 @@ func init() {
 	calcMem("Revel", func() {
 		parseRevel = loadRevel(parseAPI)
 	})
-	calcMem("Rivet", func() {
-		parseRivet = loadRivet(parseAPI)
-	})
+	// calcMem("Rivet", func() {
+	// 	parseRivet = loadRivet(parseAPI)
+	// })
 	calcMem("Tango", func() {
 		parseTango = loadTango(parseAPI)
 	})
@@ -275,10 +275,11 @@ func BenchmarkRevel_ParseStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/users", nil)
 	benchRequest(b, parseRevel, req)
 }
-func BenchmarkRivet_ParseStatic(b *testing.B) {
-	req, _ := http.NewRequest("GET", "/1/users", nil)
-	benchRequest(b, parseRivet, req)
-}
+
+// func BenchmarkRivet_ParseStatic(b *testing.B) {
+// 	req, _ := http.NewRequest("GET", "/1/users", nil)
+// 	benchRequest(b, parseRivet, req)
+// }
 func BenchmarkTango_ParseStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/users", nil)
 	benchRequest(b, parseTango, req)
@@ -395,10 +396,11 @@ func BenchmarkRevel_ParseParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/classes/go", nil)
 	benchRequest(b, parseRevel, req)
 }
-func BenchmarkRivet_ParseParam(b *testing.B) {
-	req, _ := http.NewRequest("GET", "/1/classes/go", nil)
-	benchRequest(b, parseRivet, req)
-}
+
+// func BenchmarkRivet_ParseParam(b *testing.B) {
+// 	req, _ := http.NewRequest("GET", "/1/classes/go", nil)
+// 	benchRequest(b, parseRivet, req)
+// }
 func BenchmarkTango_ParseParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/classes/go", nil)
 	benchRequest(b, parseTango, req)
@@ -515,10 +517,11 @@ func BenchmarkRevel_Parse2Params(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/classes/go/123456789", nil)
 	benchRequest(b, parseRevel, req)
 }
-func BenchmarkRivet_Parse2Params(b *testing.B) {
-	req, _ := http.NewRequest("GET", "/1/classes/go/123456789", nil)
-	benchRequest(b, parseRivet, req)
-}
+
+// func BenchmarkRivet_Parse2Params(b *testing.B) {
+// 	req, _ := http.NewRequest("GET", "/1/classes/go/123456789", nil)
+// 	benchRequest(b, parseRivet, req)
+// }
 func BenchmarkTango_Parse2Params(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/classes/go/123456789", nil)
 	benchRequest(b, parseTango, req)
@@ -612,9 +615,10 @@ func BenchmarkR2router_ParseAll(b *testing.B) {
 func BenchmarkRevel_ParseAll(b *testing.B) {
 	benchRoutes(b, parseRevel, parseAPI)
 }
-func BenchmarkRivet_ParseAll(b *testing.B) {
-	benchRoutes(b, parseRivet, parseAPI)
-}
+
+// func BenchmarkRivet_ParseAll(b *testing.B) {
+// 	benchRoutes(b, parseRivet, parseAPI)
+// }
 func BenchmarkTango_ParseAll(b *testing.B) {
 	benchRoutes(b, parseTango, parseAPI)
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -61,7 +61,6 @@ var (
 	parseBeego       http.Handler
 	parseBone        http.Handler
 	parseDenco       http.Handler
-	parseEcho        http.Handler
 	parseGin         http.Handler
 	parseGocraftWeb  http.Handler
 	parseGoji        http.Handler
@@ -84,6 +83,7 @@ var (
 	parseTigerTonic  http.Handler
 	parseTraffic     http.Handler
 	parseVulcan      http.Handler
+	// parseEcho        http.Handler
 	// parseZeus        http.Handler
 )
 
@@ -105,9 +105,9 @@ func init() {
 	calcMem("Denco", func() {
 		parseDenco = loadDenco(parseAPI)
 	})
-	calcMem("Echo", func() {
-		parseEcho = loadEcho(parseAPI)
-	})
+	// calcMem("Echo", func() {
+	// 	parseEcho = loadEcho(parseAPI)
+	// })
 	calcMem("Gin", func() {
 		parseGin = loadGin(parseAPI)
 	})
@@ -202,10 +202,11 @@ func BenchmarkDenco_ParseStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/users", nil)
 	benchRequest(b, parseDenco, req)
 }
-func BenchmarkEcho_ParseStatic(b *testing.B) {
-	req, _ := http.NewRequest("GET", "/1/users", nil)
-	benchRequest(b, parseEcho, req)
-}
+
+// func BenchmarkEcho_ParseStatic(b *testing.B) {
+// 	req, _ := http.NewRequest("GET", "/1/users", nil)
+// 	benchRequest(b, parseEcho, req)
+// }
 func BenchmarkGin_ParseStatic(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/users", nil)
 	benchRequest(b, parseGin, req)
@@ -321,10 +322,11 @@ func BenchmarkDenco_ParseParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/classes/go", nil)
 	benchRequest(b, parseDenco, req)
 }
-func BenchmarkEcho_ParseParam(b *testing.B) {
-	req, _ := http.NewRequest("GET", "/1/classes/go", nil)
-	benchRequest(b, parseEcho, req)
-}
+
+// func BenchmarkEcho_ParseParam(b *testing.B) {
+// 	req, _ := http.NewRequest("GET", "/1/classes/go", nil)
+// 	benchRequest(b, parseEcho, req)
+// }
 func BenchmarkGin_ParseParam(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/classes/go", nil)
 	benchRequest(b, parseGin, req)
@@ -440,10 +442,11 @@ func BenchmarkDenco_Parse2Params(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/classes/go/123456789", nil)
 	benchRequest(b, parseDenco, req)
 }
-func BenchmarkEcho_Parse2Params(b *testing.B) {
-	req, _ := http.NewRequest("GET", "/1/classes/go/123456789", nil)
-	benchRequest(b, parseEcho, req)
-}
+
+// func BenchmarkEcho_Parse2Params(b *testing.B) {
+// 	req, _ := http.NewRequest("GET", "/1/classes/go/123456789", nil)
+// 	benchRequest(b, parseEcho, req)
+// }
 func BenchmarkGin_Parse2Params(b *testing.B) {
 	req, _ := http.NewRequest("GET", "/1/classes/go/123456789", nil)
 	benchRequest(b, parseGin, req)
@@ -554,9 +557,10 @@ func BenchmarkBone_ParseAll(b *testing.B) {
 func BenchmarkDenco_ParseAll(b *testing.B) {
 	benchRoutes(b, parseDenco, parseAPI)
 }
-func BenchmarkEcho_ParseAll(b *testing.B) {
-	benchRoutes(b, parseEcho, parseAPI)
-}
+
+// func BenchmarkEcho_ParseAll(b *testing.B) {
+// 	benchRoutes(b, parseEcho, parseAPI)
+// }
 func BenchmarkGin_ParseAll(b *testing.B) {
 	benchRoutes(b, parseGin, parseAPI)
 }

--- a/routers.go
+++ b/routers.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gocraft/web"
 	"github.com/gorilla/mux"
 	"github.com/julienschmidt/httprouter"
-	"github.com/labstack/echo"
 	llog "github.com/lunny/log"
 	"github.com/lunny/tango"
 	vulcan "github.com/mailgun/route"
@@ -330,64 +329,64 @@ func loadDencoSingle(method, path string, h denco.HandlerFunc) http.Handler {
 }
 
 // Echo
-func echoHandler(c *echo.Context) error {
-	return nil
-}
+// func echoHandler(c echo.Context) error {
+// 	return nil
+// }
 
-func echoHandlerWrite(c *echo.Context) error {
-	io.WriteString(c.Response(), c.Param("name"))
-	return nil
-}
+// func echoHandlerWrite(c echo.Context) error {
+// 	io.WriteString(c.Response(), c.Param("name"))
+// 	return nil
+// }
 
-func echoHandlerTest(c *echo.Context) error {
-	io.WriteString(c.Response(), c.Request().RequestURI)
-	return nil
-}
+// func echoHandlerTest(c echo.Context) error {
+// 	io.WriteString(c.Response(), c.Request().URI())
+// 	return nil
+// }
 
-func loadEcho(routes []route) http.Handler {
-	var h interface{} = echoHandler
-	if loadTestHandler {
-		h = echoHandlerTest
-	}
+// func loadEcho(routes []route) http.Handler {
+// 	vh := echoHandler
+// 	if loadTestHandler {
+// 		h = echoHandlerTest
+// 	}
 
-	e := echo.New()
-	for _, r := range routes {
-		switch r.method {
-		case "GET":
-			e.Get(r.path, h)
-		case "POST":
-			e.Post(r.path, h)
-		case "PUT":
-			e.Put(r.path, h)
-		case "PATCH":
-			e.Patch(r.path, h)
-		case "DELETE":
-			e.Delete(r.path, h)
-		default:
-			panic("Unknow HTTP method: " + r.method)
-		}
-	}
-	return e
-}
+// 	e := echo.New()
+// 	for _, r := range routes {
+// 		switch r.method {
+// 		case "GET":
+// 			e.Get(r.path, h)
+// 		case "POST":
+// 			e.Post(r.path, h)
+// 		case "PUT":
+// 			e.Put(r.path, h)
+// 		case "PATCH":
+// 			e.Patch(r.path, h)
+// 		case "DELETE":
+// 			e.Delete(r.path, h)
+// 		default:
+// 			panic("Unknow HTTP method: " + r.method)
+// 		}
+// 	}
+// 	return e
+// }
 
-func loadEchoSingle(method, path string, h interface{}) http.Handler {
-	e := echo.New()
-	switch method {
-	case "GET":
-		e.Get(path, h)
-	case "POST":
-		e.Post(path, h)
-	case "PUT":
-		e.Put(path, h)
-	case "PATCH":
-		e.Patch(path, h)
-	case "DELETE":
-		e.Delete(path, h)
-	default:
-		panic("Unknow HTTP method: " + method)
-	}
-	return e
-}
+// func loadEchoSingle(method, path string, h interface{}) http.Handler {
+// 	e := echo.New()
+// 	switch method {
+// 	case "GET":
+// 		e.Get(path, h)
+// 	case "POST":
+// 		e.Post(path, h)
+// 	case "PUT":
+// 		e.Put(path, h)
+// 	case "PATCH":
+// 		e.Patch(path, h)
+// 	case "DELETE":
+// 		e.Delete(path, h)
+// 	default:
+// 		panic("Unknow HTTP method: " + method)
+// 	}
+// 	return e
+// }
 
 // Gin
 func ginHandle(_ *gin.Context) {}

--- a/routers.go
+++ b/routers.go
@@ -46,7 +46,6 @@ import (
 	"github.com/rcrowley/go-tigertonic"
 	"github.com/revel/revel"
 	"github.com/robfig/pathtree"
-	"github.com/typepress/rivet"
 	"github.com/ursiform/bear"
 	"github.com/vanng822/r2router"
 	goji "github.com/zenazn/goji/web"
@@ -1252,36 +1251,36 @@ func loadRevelSingle(method, path, action string) http.Handler {
 }
 
 // Rivet
-func rivetHandler() {}
+// func rivetHandler() {}
 
-func rivetHandlerWrite(c rivet.Context) {
-	c.WriteString(c.Get("name"))
-}
+// func rivetHandlerWrite(c rivet.Context) {
+// 	c.WriteString(c.Get("name"))
+// }
 
-func rivetHandlerTest(c rivet.Context) {
-	c.WriteString(c.Req.RequestURI)
-}
+// func rivetHandlerTest(c rivet.Context) {
+// 	c.WriteString(c.Req.URL.RequestURI())
+// }
 
-func loadRivet(routes []route) http.Handler {
-	var h interface{} = rivetHandler
-	if loadTestHandler {
-		h = rivetHandlerTest
-	}
+// func loadRivet(routes []route) http.Handler {
+// 	var h interface{} = rivetHandler
+// 	if loadTestHandler {
+// 		h = rivetHandlerTest
+// 	}
 
-	router := rivet.New()
-	for _, route := range routes {
-		router.Handle(route.method, route.path, h)
-	}
-	return router
-}
+// 	router := rivet.New()
+// 	for _, route := range routes {
+// 		router.Handle(route.method, route.path, h)
+// 	}
+// 	return router
+// }
 
-func loadRivetSingle(method, path string, handler interface{}) http.Handler {
-	router := rivet.New()
+// func loadRivetSingle(method, path string, handler interface{}) http.Handler {
+// 	router := rivet.New()
 
-	router.Handle(method, path, handler)
+// 	router.Handle(method, path, handler)
 
-	return router
-}
+// 	return router
+// }
 
 // Tango
 func tangoHandler(ctx *tango.Context) {}

--- a/routers_test.go
+++ b/routers_test.go
@@ -17,7 +17,7 @@ var (
 		{"Beego", loadBeego},
 		{"Bone", loadBone},
 		{"Denco", loadDenco},
-		{"Echo", loadEcho},
+		// {"Echo", loadEcho},
 		{"Gin", loadGin},
 		{"GocraftWeb", loadGocraftWeb},
 		{"Goji", loadGoji},

--- a/routers_test.go
+++ b/routers_test.go
@@ -35,7 +35,7 @@ var (
 		{"Possum", loadPossum},
 		{"R2router", loadR2router},
 		{"Revel", loadRevel},
-		{"Rivet", loadRivet},
+		// {"Rivet", loadRivet},
 		{"Tango", loadTango},
 		{"TigerTonic", loadTigerTonic},
 		{"Traffic", loadTraffic},

--- a/static_test.go
+++ b/static_test.go
@@ -194,12 +194,12 @@ var (
 	staticPossum      http.Handler
 	staticR2router    http.Handler
 	staticRevel       http.Handler
-	staticRivet       http.Handler
 	staticTango       http.Handler
 	staticTigerTonic  http.Handler
 	staticTraffic     http.Handler
 	staticVulcan      http.Handler
 	// staticEcho        http.Handler
+	// staticRivet       http.Handler
 	// staticZeus        http.Handler
 )
 
@@ -283,9 +283,9 @@ func init() {
 	calcMem("Revel", func() {
 		staticRevel = loadRevel(staticRoutes)
 	})
-	calcMem("Rivet", func() {
-		staticRivet = loadRivet(staticRoutes)
-	})
+	// calcMem("Rivet", func() {
+	// 	staticRivet = loadRivet(staticRoutes)
+	// })
 	calcMem("Tango", func() {
 		staticTango = loadTango(staticRoutes)
 	})
@@ -380,9 +380,10 @@ func BenchmarkR2router_StaticAll(b *testing.B) {
 func BenchmarkRevel_StaticAll(b *testing.B) {
 	benchRoutes(b, staticRevel, staticRoutes)
 }
-func BenchmarkRivet_StaticAll(b *testing.B) {
-	benchRoutes(b, staticRivet, staticRoutes)
-}
+
+// func BenchmarkRivet_StaticAll(b *testing.B) {
+// 	benchRoutes(b, staticRivet, staticRoutes)
+// }
 func BenchmarkTango_StaticAll(b *testing.B) {
 	benchRoutes(b, staticTango, staticRoutes)
 }

--- a/static_test.go
+++ b/static_test.go
@@ -177,7 +177,6 @@ var (
 	staticBeego       http.Handler
 	staticBone        http.Handler
 	staticDenco       http.Handler
-	staticEcho        http.Handler
 	staticGin         http.Handler
 	staticGocraftWeb  http.Handler
 	staticGoji        http.Handler
@@ -200,6 +199,7 @@ var (
 	staticTigerTonic  http.Handler
 	staticTraffic     http.Handler
 	staticVulcan      http.Handler
+	// staticEcho        http.Handler
 	// staticZeus        http.Handler
 )
 
@@ -229,9 +229,9 @@ func init() {
 	calcMem("Denco", func() {
 		staticDenco = loadDenco(staticRoutes)
 	})
-	calcMem("Echo", func() {
-		staticEcho = loadEcho(staticRoutes)
-	})
+	// calcMem("Echo", func() {
+	// 	staticEcho = loadEcho(staticRoutes)
+	// })
 	calcMem("Gin", func() {
 		staticGin = loadGin(staticRoutes)
 	})
@@ -325,9 +325,10 @@ func BenchmarkBone_StaticAll(b *testing.B) {
 func BenchmarkDenco_StaticAll(b *testing.B) {
 	benchRoutes(b, staticDenco, staticRoutes)
 }
-func BenchmarkEcho_StaticAll(b *testing.B) {
-	benchRoutes(b, staticEcho, staticRoutes)
-}
+
+// func BenchmarkEcho_StaticAll(b *testing.B) {
+// 	benchRoutes(b, staticEcho, staticRoutes)
+// }
 func BenchmarkGin_StaticAll(b *testing.B) {
 	benchRoutes(b, staticGin, staticRoutes)
 }


### PR DESCRIPTION
- put dependencies under `glide` management, will make it easier to keep this benchmark functional.
- disable benchmarking the `echo` framework
  - The Echo framework has changed a bunch of its interfaces, and no longer
    implements `http.Handler` in doing so. As such, Echo no longer works
    within this framework.
- disable the `rivet` framework
  - In testing, the `rivet` framework was returning 200s but the body was always empty. This looks to be an issue within `rivet` and less to with the benchmark
