### PR TITLE
Fix Markdown typo in README.md's Note

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ go test -bench=.
 
 > **Note:** If you run the tests and it SIGQUIT's make the go test timeout longer (#44)
 >
->```
+```
 go test -timeout=2h -bench=.
 ```
 


### PR DESCRIPTION
A tiny typo fix in _Usage_'s _Note_ section from _README.md_. 