### PR TITLE
init CloudyKitRouter router in parseAPI benchmarks

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -112,6 +112,9 @@ func init() {
 	calcMem("Chi", func() {
 		parseChi = loadChi(parseAPI)
 	})
+	calcMem("CloudyKitRouter", func() {
+		parseCloudyKitRouter = loadCloudyKitRouter(parseAPI)
+	})
 	calcMem("Denco", func() {
 		parseDenco = loadDenco(parseAPI)
 	})


### PR DESCRIPTION
Currently, `CloudyKitRouter` is not initialized in the parseAPI benchmarks so they break. 